### PR TITLE
Add boot auto-configuration and spring events

### DIFF
--- a/docs/src/main/asciidoc/leaderelection.adoc
+++ b/docs/src/main/asciidoc/leaderelection.adoc
@@ -1,0 +1,104 @@
+== Leader Election
+
+Leader election allows application to work together with other
+applications to coordinate a cluster leadership via a third party system.
+Currently we provide integrations with `zookeeper` and `hazelcast`.
+
+From user perspective election is working via interfaces
+`org.springframework.cloud.cluster.leader.Candidate` and
+`org.springframework.cloud.cluster.leader.Context`. `Candidate`
+contains access to leadership's `role` and `id` and also have methods
+`onGranted` and `onRevoked`. These callback methods are useful if
+default `Candidate` implementation is changed.
+
+Leader election is auto-configured if either
+`spring-cloud-cluster-hazelcast` or
+`spring-cloud-cluster-zookeeper` jars are found from a classpath. In
+case where both jars are found leader election is created using both
+systems. See sections <<spring-cloud-cluster-leaderelection-zookeeper>>
+and <<spring-cloud-cluster-leaderelection-hazelcast>> for more
+information about a created beans.
+
+Default `Candidate` created from auto-configuration is
+`org.springframework.cloud.cluster.leader.DefaultCandidate` which
+currently only logs granted and revoked events.
+
+If there's a need for disable all leader related auto-configuration,
+a `spring.cloud.cluster.leader.enabled` can be set to false which
+then allows to do manual configuration even if the jars an on a
+classpath. Properties `spring.cloud.cluster.leader.id` and
+`spring.cloud.cluster.leader.role` can be used to set default
+identifier and role.
+
+If you are interested to simple get notification of granted and
+revoked events one option is to attach event listener into spring
+application context. Events `OnGrantedEvent` and `OnRevokedEvent` are
+sent as spring event objects.
+
+Simply create your own event listener class:
+[source,java]
+----
+class MyEventListener implements ApplicationListener<AbstractLeaderEvent> {
+
+  @Override
+  public void onApplicationEvent(AbstractLeaderEvent event) {
+    // do something with OnGrantedEvent or OnRevokedEvent
+  }
+}
+----
+
+and then create it as a bean.
+
+[source,java]
+----
+@Configuration
+static class Config {
+  @Bean
+  public MyEventListener myEventListener() {
+    return new MyEventListener();
+  }
+}
+----
+
+For simply log events you can also use a utility class
+`LoggingListener` which allows easy configuration.
+
+[source,java]
+----
+import org.springframework.cloud.cluster.leader.event.LoggingListener;
+
+@Configuration
+static class Config {
+  @Bean
+  public LoggingListener loggingListener() {
+    return new LoggingListener("info");
+  }
+}
+----
+
+[[spring-cloud-cluster-leaderelection-zookeeper]]
+=== Zookeeper
+`Candidate` implementation for zookeeper is created with a bean name
+`zookeeperLeaderCandidate` which can be used to override the one
+created during auto-configuration.
+
+Zookeeper based election can be explicitly disabled using property
+`spring.cloud.cluster.zookeeper.enabled`.
+
+Other propertys `spring.cloud.cluster.zookeeper.namespace` and
+`spring.cloud.cluster.zookeeper.connect` can be used to set the
+zookeeper base namespace path and connect string.
+
+[[spring-cloud-cluster-leaderelection-hazelcast]]
+=== Hazelcast
+`Candidate` implementation for zookeeper is created with a bean name
+`hazelcastLeaderCandidate` which can be used to override the one
+created during auto-configuration.
+
+Hazelcast based election can be explicitly disabled using property
+`spring.cloud.cluster.hazelcast.enabled`. If you want to provide xml
+based configuration for Hazelcast instance use property
+`spring.cloud.cluster.hazelcast.config-location` to tell location of a
+Hazelcast xml configuration file. `config-location` is a normal spring
+`Resource`.
+

--- a/docs/src/main/asciidoc/spring-cloud-cluster.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-cluster.adoc
@@ -1,3 +1,5 @@
 = Spring Cloud Cluster
 
 include::intro.adoc[]
+
+include::leaderelection.adoc[]

--- a/spring-cloud-cluster-core/pom.xml
+++ b/spring-cloud-cluster-core/pom.xml
@@ -27,6 +27,11 @@
 			<artifactId>spring-boot-starter</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>
 			<scope>test</scope>

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/AbstractCandidate.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/AbstractCandidate.java
@@ -17,6 +17,8 @@ package org.springframework.cloud.cluster.leader;
 
 import java.util.UUID;
 
+import org.springframework.util.StringUtils;
+
 /**
  * Base implementation of a {@link Candidate}.
  * 
@@ -31,13 +33,22 @@ public abstract class AbstractCandidate implements Candidate {
 	
 	private final String role;
 	
+	/**
+	 * Instantiate a abstract candidate.
+	 */
 	public AbstractCandidate() {
-		this(UUID.randomUUID().toString(), DEFAULT_ROLE);
+		this(null, null);
 	}
 
+	/**
+	 * Instantiate a abstract candidate.
+	 * 
+	 * @param id the identifier
+	 * @param role the role
+	 */
 	public AbstractCandidate(String id, String role) {
-		this.id = id;
-		this.role = role;
+		this.id = StringUtils.hasText(id) ? id : UUID.randomUUID().toString();
+		this.role = StringUtils.hasText(role) ? role : DEFAULT_ROLE;
 	}
 
 	@Override

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/DefaultCandidate.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/DefaultCandidate.java
@@ -28,10 +28,19 @@ public class DefaultCandidate extends AbstractCandidate {
 
 	private volatile Context leaderContext;
 
+	/**
+	 * Instantiate a default candidate.
+	 */
 	public DefaultCandidate() {
 		super();
 	}
 
+	/**
+	 * Instantiate a default candidate.
+	 * 
+	 * @param id the identifier
+	 * @param role the role
+	 */
 	public DefaultCandidate(String id, String role) {
 		super(id, role);
 	}

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/LeaderElectionProperties.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/LeaderElectionProperties.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.leader;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Generic configuration properties for leader election.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+@ConfigurationProperties(value = "spring.cloud.cluster.leader")
+public class LeaderElectionProperties {
+
+	/** if leader election is enabled globally. */
+	private boolean enabled = true;
+	
+	/** leader election candidate identifier. */
+	private String id;
+	
+	/** leader election candidate role. */
+	private String role;
+	
+	public boolean isEnabled() {
+		return enabled;
+	}
+	
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+	
+	public String getId() {
+		return id;
+	}
+	
+	public void setId(String id) {
+		this.id = id;
+	}
+	
+	public String getRole() {
+		return role;
+	}
+	
+	public void setRole(String role) {
+		this.role = role;
+	}
+	
+}

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/AbstractLeaderEvent.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/AbstractLeaderEvent.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.leader.event;
+
+import org.springframework.cloud.cluster.leader.Context;
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * Base {@link ApplicationEvent} class for leader based events. All custom event
+ * classes should be derived from this class.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@SuppressWarnings("serial")
+public abstract class AbstractLeaderEvent extends ApplicationEvent {
+
+	private Context context;
+	
+	/**
+	 * Create a new ApplicationEvent.
+	 *
+	 * @param source the component that published the event (never {@code null})
+	 */
+	public AbstractLeaderEvent(Object source) {
+		super(source);
+	}
+
+	/**
+	 * Create a new ApplicationEvent.
+	 *
+	 * @param source the component that published the event (never {@code null})
+	 * @param context the context associated with this event
+	 */
+	public AbstractLeaderEvent(Object source, Context context) {
+		super(source);
+		this.context = context;
+	}
+
+	/**
+	 * Gets the {@link Context} associated with this event.
+	 * 
+	 * @return the context
+	 */
+	public Context getContext() {
+		return context;
+	}
+
+	@Override
+	public String toString() {
+		return "AbstractLeaderEvent [context=" + context + ", source=" + source
+				+ "]";
+	}
+
+}

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/DefaultLeaderEventPublisher.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/DefaultLeaderEventPublisher.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.leader.event;
+
+import org.springframework.cloud.cluster.leader.Context;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
+
+/**
+ * Default implementation of {@link LeaderEventPublisher}.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public class DefaultLeaderEventPublisher implements LeaderEventPublisher, ApplicationEventPublisherAware {
+
+	private ApplicationEventPublisher applicationEventPublisher;
+
+	/**
+	 * Instantiates a new leader event publisher.
+	 */
+	public DefaultLeaderEventPublisher() {
+	}
+
+	/**
+	 * Instantiates a new leader event publisher.
+	 * 
+	 * @param applicationEventPublisher the application event publisher
+	 */
+	public DefaultLeaderEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+		this.applicationEventPublisher = applicationEventPublisher;
+	}
+	
+	@Override
+	public void publishOnGranted(Object source, Context context) {
+		if (applicationEventPublisher != null) {
+			applicationEventPublisher.publishEvent(new OnGrantedEvent(source, context));
+		}
+	}
+
+	@Override
+	public void publishOnRevoked(Object source, Context context) {
+		if (applicationEventPublisher != null) {
+			applicationEventPublisher.publishEvent(new OnRevokedEvent(source, context));
+		}
+	}
+
+	@Override
+	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+		this.applicationEventPublisher = applicationEventPublisher;
+	}
+	
+}

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/LeaderEventPublisher.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/LeaderEventPublisher.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.leader.event;
+
+import org.springframework.cloud.cluster.leader.Context;
+
+/**
+ * Interface for publishing leader based application events.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public interface LeaderEventPublisher {
+
+	/**
+	 * Publish a granted event.
+	 * 
+	 * @param source the component generated this event
+	 * @param context the context associated with event
+	 */
+	void publishOnGranted(Object source, Context context);
+
+	/**
+	 * Publish a revoked event.
+	 * 
+	 * @param source the component generated this event
+	 * @param context the context associated with event
+	 */
+	void publishOnRevoked(Object source, Context context);
+	
+}

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/LeaderEventPublisherConfiguration.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/LeaderEventPublisherConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.leader.event;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration for common {@link LeaderEventPublisher}.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+@Configuration
+public class LeaderEventPublisherConfiguration {
+
+	@Bean
+	public LeaderEventPublisher leaderEventPublisher() {
+		return new DefaultLeaderEventPublisher();
+	}
+	
+}

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/LoggingListener.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/LoggingListener.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.leader.event;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationListener;
+import org.springframework.util.StringUtils;
+
+/**
+ * Simple {@link ApplicationListener} which logs all events
+ * based on {@link AbstractLeaderEvent} using a log level
+ * set during the construction.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class LoggingListener implements ApplicationListener<AbstractLeaderEvent> {
+
+	private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+	/** Internal enums to match the log level */
+	private static enum Level {
+		ERROR, WARN, INFO, DEBUG, TRACE
+	}
+
+	/** Level to use */
+	private final Level level;
+
+	/**
+	 * Constructs Logger listener with debug level.
+	 */
+	public LoggingListener() {
+		level = Level.DEBUG;
+	}
+
+	/**
+	 * Constructs Logger listener with given level.
+	 *
+	 * @param level the level string
+	 */
+	public LoggingListener(String level) {
+		try {
+			this.level = Level.valueOf(level.toUpperCase());
+		}
+		catch (IllegalArgumentException e) {
+			throw new IllegalArgumentException("Invalid log level '" + level
+					+ "'. The (case-insensitive) supported values are: "
+					+ StringUtils.arrayToCommaDelimitedString(Level.values()));
+		}
+	}
+
+	@Override
+	public void onApplicationEvent(AbstractLeaderEvent event) {
+		switch (this.level) {
+		case ERROR:
+			if (logger.isErrorEnabled()) {
+				logger.error(event.toString());
+			}
+			break;
+		case WARN:
+			if (logger.isWarnEnabled()) {
+				logger.warn(event.toString());
+			}
+			break;
+		case INFO:
+			if (logger.isInfoEnabled()) {
+				logger.info(event.toString());
+			}
+			break;
+		case DEBUG:
+			if (logger.isDebugEnabled()) {
+				logger.debug(event.toString());
+			}
+			break;
+		case TRACE:
+			if (logger.isTraceEnabled()) {
+				logger.trace(event.toString());
+			}
+			break;
+		}
+	}
+
+}

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/OnGrantedEvent.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/OnGrantedEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.leader.event;
+
+import org.springframework.cloud.cluster.leader.Context;
+
+/**
+ * Generic event representing that leader has been granted.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@SuppressWarnings("serial")
+public class OnGrantedEvent extends AbstractLeaderEvent {
+
+	/**
+	 * Instantiates a new granted event.
+	 * 
+	 * @param source the component that published the event (never {@code null})
+	 * @param context the context associated with this event
+	 */
+	public OnGrantedEvent(Object source, Context context) {
+		super(source, context);
+	}
+
+}

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/OnRevokedEvent.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/OnRevokedEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.leader.event;
+
+import org.springframework.cloud.cluster.leader.Context;
+
+/**
+ * Generic event representing that leader has been revoked.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@SuppressWarnings("serial")
+public class OnRevokedEvent extends AbstractLeaderEvent {
+
+	/**
+	 * Instantiates a new revoked event.
+	 * 
+	 * @param source the component that published the event (never {@code null})
+	 * @param context the context associated with this event
+	 */
+	public OnRevokedEvent(Object source, Context context) {
+		super(source, context);
+	}
+
+}

--- a/spring-cloud-cluster-hazelcast/pom.xml
+++ b/spring-cloud-cluster-hazelcast/pom.xml
@@ -23,6 +23,11 @@
 			<artifactId>spring-cloud-cluster-core</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<artifactId>hazelcast</artifactId>
 			<groupId>com.hazelcast</groupId>
 		</dependency>

--- a/spring-cloud-cluster-hazelcast/src/main/java/org/springframework/cloud/cluster/hazelcast/leader/HazelcastLeaderAutoConfiguration.java
+++ b/spring-cloud-cluster-hazelcast/src/main/java/org/springframework/cloud/cluster/hazelcast/leader/HazelcastLeaderAutoConfiguration.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.hazelcast.leader;
+
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.cluster.leader.Candidate;
+import org.springframework.cloud.cluster.leader.DefaultCandidate;
+import org.springframework.cloud.cluster.leader.LeaderElectionProperties;
+import org.springframework.cloud.cluster.leader.event.LeaderEventPublisher;
+import org.springframework.cloud.cluster.leader.event.LeaderEventPublisherConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.io.Resource;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.XmlConfigBuilder;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+
+/**
+ * Auto-configuration for hazelcast leader election.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+@Configuration
+@ConditionalOnProperty(value = "spring.cloud.cluster.leader.enabled", matchIfMissing = true)
+@ConditionalOnMissingBean(name = "hazelcastLeaderInitiator")
+public class HazelcastLeaderAutoConfiguration {
+
+	@Configuration
+	@EnableConfigurationProperties({ LeaderElectionProperties.class, HazelcastProperties.class })
+	@ConditionalOnProperty(value = "spring.cloud.cluster.hazelcast.enabled", matchIfMissing = true)
+	@Import(LeaderEventPublisherConfiguration.class)
+	protected static class RuntimeConfig {
+
+		@Autowired
+		private LeaderElectionProperties lep;
+		
+		@Autowired
+		private HazelcastProperties hp;
+
+		@Autowired
+		private LeaderEventPublisher publisher;
+
+		@Bean
+		public Candidate hazelcastLeaderCandidate() {
+			return new DefaultCandidate(lep.getId(), lep.getRole());
+		}
+
+		@Bean
+		public HazelcastInstance hazelcastInstance() {
+			return Hazelcast.newHazelcastInstance(hazelcastConfig());
+		}
+
+		@Bean
+		public LeaderInitiator hazelcastLeaderInitiator() {
+			LeaderInitiator initiator = new LeaderInitiator(
+					hazelcastInstance(), hazelcastLeaderCandidate());
+			initiator.setLeaderEventPublisher(publisher);
+			return initiator;
+		}
+		
+		@Bean
+		public Config hazelcastConfig() {
+			Resource location = hp.getConfigLocation();
+			if (location != null && location.exists()) {
+				try {
+					return new XmlConfigBuilder(hp.getConfigLocation().getInputStream()).build();
+				} catch (IOException e) {
+					throw new IllegalArgumentException("Unable to use config location " + location, e);
+				}
+			} else {
+				return new Config();				
+			}
+		}
+		
+	}
+		
+}

--- a/spring-cloud-cluster-hazelcast/src/main/java/org/springframework/cloud/cluster/hazelcast/leader/HazelcastProperties.java
+++ b/spring-cloud-cluster-hazelcast/src/main/java/org/springframework/cloud/cluster/hazelcast/leader/HazelcastProperties.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.hazelcast.leader;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.io.Resource;
+
+/**
+ * Configuration properties for hazelcast leader election.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+@ConfigurationProperties(value = "spring.cloud.cluster.hazelcast")
+public class HazelcastProperties {
+
+	/** if hazelcast leader election is enabled. */
+	private boolean enabled = true;
+	
+	/** xml config location for hazelcast configuration. */
+	private Resource configLocation;
+	
+	public boolean isEnabled() {
+		return enabled;
+	}
+	
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+	
+	public Resource getConfigLocation() {
+		return configLocation;
+	}
+	
+	public void setConfigLocation(Resource configLocation) {
+		this.configLocation = configLocation;
+	}
+	
+}

--- a/spring-cloud-cluster-hazelcast/src/main/java/org/springframework/cloud/cluster/hazelcast/leader/LeaderInitiator.java
+++ b/spring-cloud-cluster-hazelcast/src/main/java/org/springframework/cloud/cluster/hazelcast/leader/LeaderInitiator.java
@@ -23,15 +23,16 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
-
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.cloud.cluster.leader.Candidate;
 import org.springframework.cloud.cluster.leader.Context;
+import org.springframework.cloud.cluster.leader.event.LeaderEventPublisher;
 import org.springframework.context.Lifecycle;
 import org.springframework.util.Assert;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
 
 /**
  * Bootstrap leadership {@link org.springframework.cloud.cluster.leader.Candidate candidates}
@@ -81,6 +82,9 @@ public class LeaderInitiator implements Lifecycle, InitializingBean, DisposableB
 	 */
 	private volatile boolean running;
 
+	/** Leader event publisher if set */
+	private LeaderEventPublisher leaderEventPublisher;
+	
 	/**
 	 * Construct a {@link LeaderInitiator}.
 	 *
@@ -134,7 +138,16 @@ public class LeaderInitiator implements Lifecycle, InitializingBean, DisposableB
 		stop();
 		executorService.shutdown();
 	}
-
+	
+	/**
+	 * Sets the {@link LeaderEventPublisher}.
+	 * 
+	 * @param leaderEventPublisher the event publisher
+	 */
+	public void setLeaderEventPublisher(LeaderEventPublisher leaderEventPublisher) {
+		this.leaderEventPublisher = leaderEventPublisher;
+	}
+	
 	/**
 	 * Callable that manages the acquisition of Hazelcast locks
 	 * for leadership election.
@@ -154,6 +167,9 @@ public class LeaderInitiator implements Lifecycle, InitializingBean, DisposableB
 					if (locked) {
 						mapLocks.put(role, candidate.getId());
 						candidate.onGranted(context);
+						if (leaderEventPublisher != null) {
+							leaderEventPublisher.publishOnGranted(LeaderInitiator.this, context);
+						}
 						Thread.sleep(Long.MAX_VALUE);
 					}
 				}
@@ -167,6 +183,9 @@ public class LeaderInitiator implements Lifecycle, InitializingBean, DisposableB
 						mapLocks.remove(role);
 						mapLocks.unlock(role);
 						candidate.onRevoked(context);
+						if (leaderEventPublisher != null) {
+							leaderEventPublisher.publishOnRevoked(LeaderInitiator.this, context);
+						}
 						locked = false;
 					}
 				}

--- a/spring-cloud-cluster-hazelcast/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-cluster-hazelcast/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.springframework.cloud.cluster.hazelcast.leader.HazelcastLeaderAutoConfiguration

--- a/spring-cloud-cluster-hazelcast/src/test/java/org/springframework/cloud/cluster/hazelcast/leader/HazelcastLeaderAutoConfigurationTests.java
+++ b/spring-cloud-cluster-hazelcast/src/test/java/org/springframework/cloud/cluster/hazelcast/leader/HazelcastLeaderAutoConfigurationTests.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.hazelcast.leader;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.hazelcast.config.Config;
+
+/**
+ * Tests for {@link HazelcastLeaderAutoConfiguration}.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public class HazelcastLeaderAutoConfigurationTests {
+
+	private AnnotationConfigApplicationContext context;
+
+	@After
+	public void close() {
+		if (context != null) {
+			context.close();
+		}
+	}
+
+	@Test
+	public void testDefaults() throws Exception {
+		context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context);
+		context.register(HazelcastLeaderAutoConfiguration.class);
+		context.refresh();
+		
+		assertThat(context.containsBean("hazelcastLeaderInitiator"), is(true));
+		assertThat(context.containsBean("hazelcastLeaderCandidate"), is(true));
+	}
+
+	@Test
+	public void testDisabled() throws Exception {
+		context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.cloud.cluster.hazelcast.enabled:false");
+		context.register(HazelcastLeaderAutoConfiguration.class);
+		context.refresh();
+		
+		assertThat(context.containsBean("hazelcastLeaderInitiator"), is(false));
+		assertThat(context.containsBean("hazelcastLeaderCandidate"), is(false));
+	}
+	
+	@Test
+	public void testGlobalLeaderDisabled() throws Exception {
+		context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils
+				.addEnvironment(
+						this.context,
+						"spring.cloud.cluster.leader.enabled:false",
+						"spring.cloud.cluster.hazelcast.enabled:true");
+		context.register(HazelcastLeaderAutoConfiguration.class);
+		context.refresh();
+		
+		assertThat(context.containsBean("hazelcastLeaderInitiator"), is(false));
+		assertThat(context.containsBean("hazelcastLeaderCandidate"), is(false));
+	}
+	
+	@Test
+	public void testEnabled() throws Exception {
+		context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils
+				.addEnvironment(
+						this.context,
+						"spring.cloud.cluster.hazelcast.enabled:true");
+		context.register(HazelcastLeaderAutoConfiguration.class);
+		context.refresh();
+		
+		assertThat(context.containsBean("hazelcastLeaderInitiator"), is(true));
+		assertThat(context.containsBean("hazelcastLeaderCandidate"), is(true));
+	}
+	
+	@Test
+	public void testOverrideConfig() throws Exception {
+		context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context);
+		context.register(HazelcastLeaderAutoConfiguration.class, OverrideConfig.class);
+		context.refresh();
+		
+		Config config = context.getBean("hazelcastConfig", Config.class);
+		assertThat(config, notNullValue());
+		assertThat(config.getProperty("foo"), is("bar"));
+		assertThat(config.getProperty("bar"), nullValue());
+		
+		assertThat(context.containsBean("hazelcastLeaderInitiator"), is(true));
+		assertThat(context.containsBean("hazelcastLeaderCandidate"), is(true));
+	}
+
+	@Test
+	public void testXmlConfig() throws Exception {
+		context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.cloud.cluster.hazelcast.config-location:classpath:/foobar.xml");
+		context.register(HazelcastLeaderAutoConfiguration.class);
+		context.refresh();
+		
+		Config config = context.getBean("hazelcastConfig", Config.class);
+		assertThat(config, notNullValue());
+		assertThat(config.getProperty("foo"), is("bar"));
+		assertThat(config.getProperty("bar"), is("foo"));
+		
+		assertThat(context.containsBean("hazelcastLeaderInitiator"), is(true));
+		assertThat(context.containsBean("hazelcastLeaderCandidate"), is(true));
+	}
+	
+	@Configuration
+	protected static class OverrideConfig {
+		
+		@Bean
+		public Config hazelcastConfig() {
+			Config config = new Config();
+			config.setProperty("foo", "bar");
+			return config;
+		}
+		
+	}
+	
+}

--- a/spring-cloud-cluster-hazelcast/src/test/resources/foobar.xml
+++ b/spring-cloud-cluster-hazelcast/src/test/resources/foobar.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast
+	xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.4.xsd"
+	xmlns="http://www.hazelcast.com/schema/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+	<properties>
+		<property name="foo">bar</property>
+		<property name="bar">foo</property>
+	</properties>
+
+</hazelcast>

--- a/spring-cloud-cluster-zookeeper/pom.xml
+++ b/spring-cloud-cluster-zookeeper/pom.xml
@@ -23,6 +23,11 @@
 			<artifactId>spring-cloud-cluster-core</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.curator</groupId>
 			<artifactId>curator-recipes</artifactId>
 		</dependency>

--- a/spring-cloud-cluster-zookeeper/src/main/java/org/springframework/cloud/cluster/zk/leader/ZookeeperLeaderAutoConfiguration.java
+++ b/spring-cloud-cluster-zookeeper/src/main/java/org/springframework/cloud/cluster/zk/leader/ZookeeperLeaderAutoConfiguration.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.zk.leader;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.cluster.leader.Candidate;
+import org.springframework.cloud.cluster.leader.DefaultCandidate;
+import org.springframework.cloud.cluster.leader.LeaderElectionProperties;
+import org.springframework.cloud.cluster.leader.event.LeaderEventPublisher;
+import org.springframework.cloud.cluster.leader.event.LeaderEventPublisherConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Auto-configuration for zookeeper leader election.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+@Configuration
+@ConditionalOnProperty(value = "spring.cloud.cluster.leader.enabled", matchIfMissing = true)
+@ConditionalOnMissingBean(name = "zookeeperLeaderInitiator")
+public class ZookeeperLeaderAutoConfiguration {
+
+	@Configuration
+	@EnableConfigurationProperties({ LeaderElectionProperties.class, ZookeeperProperties.class })
+	@ConditionalOnProperty(value = "spring.cloud.cluster.zookeeper.enabled", matchIfMissing = true)
+	@Import(LeaderEventPublisherConfiguration.class)
+	protected static class RuntimeConfig {
+
+		@Autowired
+		private LeaderElectionProperties lep;
+		
+		@Autowired
+		private ZookeeperProperties zkp;
+		
+		@Autowired
+		private LeaderEventPublisher publisher;
+		
+		@Bean
+		public Candidate zookeeperLeaderCandidate() {
+			return new DefaultCandidate(lep.getId(), lep.getRole());
+		}
+
+		@Bean
+		public CuratorFramework curatorClient() throws Exception {
+			CuratorFramework client = CuratorFrameworkFactory.builder().defaultData(new byte[0])
+					.retryPolicy(new ExponentialBackoffRetry(1000, 3))
+					.connectString(zkp.getConnect()).build();
+			return client;
+		}
+
+		@Bean
+		public LeaderInitiator zookeeperLeaderInitiator() throws Exception {
+			LeaderInitiator initiator = new LeaderInitiator(curatorClient(),
+					zookeeperLeaderCandidate(), zkp.getNamespace());
+			initiator.setLeaderEventPublisher(publisher);
+			return initiator;
+		}	
+		
+	}
+
+}

--- a/spring-cloud-cluster-zookeeper/src/main/java/org/springframework/cloud/cluster/zk/leader/ZookeeperProperties.java
+++ b/spring-cloud-cluster-zookeeper/src/main/java/org/springframework/cloud/cluster/zk/leader/ZookeeperProperties.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.zk.leader;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for zookeeper leader election.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+@ConfigurationProperties(value = "spring.cloud.cluster.zookeeper")
+public class ZookeeperProperties {
+
+	/** if zookeeper leader election is enabled. */
+	private boolean enabled = true;
+	
+	/** base zookeeper namespace path. */
+	private String namespace;
+	
+	/** connect string for zookeeper. */
+	private String connect = "localhost:2181";
+	
+	public boolean isEnabled() {
+		return enabled;
+	}
+	
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public String getNamespace() {
+		return namespace;
+	}
+
+	public void setNamespace(String namespace) {
+		this.namespace = namespace;
+	}
+
+	public String getConnect() {
+		return connect;
+	}
+
+	public void setConnect(String connect) {
+		this.connect = connect;
+	}
+	
+}

--- a/spring-cloud-cluster-zookeeper/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-cluster-zookeeper/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.springframework.cloud.cluster.zk.leader.ZookeeperLeaderAutoConfiguration

--- a/spring-cloud-cluster-zookeeper/src/test/java/org/springframework/cloud/cluster/zk/leader/ZookeeperLeaderAutoConfigurationTests.java
+++ b/spring-cloud-cluster-zookeeper/src/test/java/org/springframework/cloud/cluster/zk/leader/ZookeeperLeaderAutoConfigurationTests.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.zk.leader;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+/**
+ * Tests for {@link ZookeeperLeaderAutoConfiguration}.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public class ZookeeperLeaderAutoConfigurationTests {
+
+	private AnnotationConfigApplicationContext context;
+	
+	private TestingServerWrapper server;
+
+	@After
+	public void close() {
+		if (context != null) {
+			context.close();
+		}
+		if (server != null) {
+			try {
+				server.destroy();
+			} catch (Exception e) {
+			}
+			server = null;
+		}
+	}
+	
+	@Test
+	public void testDefaults() throws Exception {
+		server = new TestingServerWrapper();
+		context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context);
+		context.register(ZookeeperLeaderAutoConfiguration.class);
+		context.refresh();
+		
+		assertThat(context.containsBean("zookeeperLeaderInitiator"), is(true));
+		assertThat(context.containsBean("zookeeperLeaderCandidate"), is(true));
+	}
+
+	@Test
+	public void testEnabled() throws Exception {
+		server = new TestingServerWrapper();
+		context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils
+				.addEnvironment(
+						this.context,
+						"spring.cloud.cluster.zookeeper.enabled:true",
+						"spring.cloud.cluster.zookeeper.connect:localhost:" + server.getPort());
+		context.register(ZookeeperLeaderAutoConfiguration.class);
+		context.refresh();
+		
+		assertThat(context.containsBean("zookeeperLeaderInitiator"), is(true));
+		assertThat(context.containsBean("zookeeperLeaderCandidate"), is(true));
+	}
+
+	@Test
+	public void testDisabled() throws Exception {
+		context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils
+				.addEnvironment(
+						this.context,
+						"spring.cloud.cluster.zookeeper.enabled:false");
+		context.register(ZookeeperLeaderAutoConfiguration.class);
+		context.refresh();
+		
+		assertThat(context.containsBean("zookeeperLeaderInitiator"), is(false));
+		assertThat(context.containsBean("zookeeperLeaderCandidate"), is(false));
+	}
+
+	@Test
+	public void testGlobalLeaderDisabled() throws Exception {
+		context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils
+				.addEnvironment(
+						this.context,
+						"spring.cloud.cluster.leader.enabled:false",
+						"spring.cloud.cluster.zookeeper.enabled:true");
+		context.register(ZookeeperLeaderAutoConfiguration.class);
+		context.refresh();
+		
+		assertThat(context.containsBean("zookeeperLeaderInitiator"), is(false));
+		assertThat(context.containsBean("zookeeperLeaderCandidate"), is(false));
+	}
+	
+	static class TestingServerWrapper implements DisposableBean {
+
+		TestingServer testingServer;
+
+		public TestingServerWrapper() throws Exception {
+			this.testingServer = new TestingServer(true);
+		}
+
+		@Override
+		public void destroy() throws Exception {
+			try {
+				testingServer.close();
+			}
+			catch (IOException e) {
+			}
+		}
+
+		public int getPort() {
+			return testingServer.getPort();
+		}
+
+	}
+	
+}


### PR DESCRIPTION
Check `docs/src/main/asciidoc/leaderelection.adoc` for more info about what we have here.

- Auto-configuration for both hazelcast and zookeeper.
- Generates boot props metadata.
- Both hazelcast and zookeeper leader election can
  co-exist at a same time to make configuration easier.
  There are flags to disable election for both hazelcast
  and zookeeper or globally.
- Granted and revoked actions are also published as event
  objects via spring context.