### PR TITLE
Add boot auto-configuration and spring events

### DIFF
--- a/docs/src/main/asciidoc/leaderelection.adoc
+++ b/docs/src/main/asciidoc/leaderelection.adoc
@@ -1,0 +1,105 @@
+== Leader Election
+
+Leader election allows application to work together with other
+applications to coordinate a cluster leadership via a third party system.
+Currently we provide integrations with `zookeeper` and `hazelcast`.
+
+From user perspective election is working via interfaces
+`org.springframework.cloud.cluster.leader.Candidate` and
+`org.springframework.cloud.cluster.leader.Context`. `Candidate`
+contains access to leadership's `role` and `id` and also have methods
+`onGranted` and `onRevoked`. These callback methods are useful if
+default `Candidate` implementation is changed.
+
+Leader election is auto-configured if 
+`spring-cloud-cluster-autoconfigure`
+and either `spring-cloud-cluster-hazelcast` or
+`spring-cloud-cluster-zookeeper` jars are found from a classpath. In
+case where both jars are found leader election is created using both
+systems. See sections <<spring-cloud-cluster-leaderelection-zookeeper>>
+and <<spring-cloud-cluster-leaderelection-hazelcast>> for more
+information about a created beans.
+
+Default `Candidate` created from auto-configuration is
+`org.springframework.cloud.cluster.leader.DefaultCandidate` which
+currently only logs granted and revoked events.
+
+If there's a need for disable all leader related auto-configuration,
+a `spring.cloud.cluster.leader.enabled` can be set to false which
+then allows to do manual configuration even if the jars an on a
+classpath. Properties `spring.cloud.cluster.leader.id` and
+`spring.cloud.cluster.leader.role` can be used to set default
+identifier and role.
+
+If you are interested to simple get notification of granted and
+revoked events one option is to attach event listener into spring
+application context. Events `OnGrantedEvent` and `OnRevokedEvent` are
+sent as spring event objects.
+
+Simply create your own event listener class:
+[source,java]
+----
+class MyEventListener implements ApplicationListener<AbstractLeaderEvent> {
+
+  @Override
+  public void onApplicationEvent(AbstractLeaderEvent event) {
+    // do something with OnGrantedEvent or OnRevokedEvent
+  }
+}
+----
+
+and then create it as a bean.
+
+[source,java]
+----
+@Configuration
+static class Config {
+  @Bean
+  public MyEventListener myEventListener() {
+    return new MyEventListener();
+  }
+}
+----
+
+For simply log events you can also use a utility class
+`LoggingListener` which allows easy configuration.
+
+[source,java]
+----
+import org.springframework.cloud.cluster.leader.event.LoggingListener;
+
+@Configuration
+static class Config {
+  @Bean
+  public LoggingListener loggingListener() {
+    return new LoggingListener("info");
+  }
+}
+----
+
+[[spring-cloud-cluster-leaderelection-zookeeper]]
+=== Zookeeper
+`Candidate` implementation for zookeeper is created with a bean name
+`zookeeperLeaderCandidate` which can be used to override the one
+created during auto-configuration.
+
+Zookeeper based election can be explicitly disabled using property
+`spring.cloud.cluster.zookeeper.leader.enabled`.
+
+Other propertys `spring.cloud.cluster.zookeeper.namespace` and
+`spring.cloud.cluster.zookeeper.connect` can be used to set the
+zookeeper base namespace path and connect string.
+
+[[spring-cloud-cluster-leaderelection-hazelcast]]
+=== Hazelcast
+`Candidate` implementation for zookeeper is created with a bean name
+`hazelcastLeaderCandidate` which can be used to override the one
+created during auto-configuration.
+
+Hazelcast based election can be explicitly disabled using property
+`spring.cloud.cluster.hazelcast.leader.enabled`. If you want to provide xml
+based configuration for Hazelcast instance use property
+`spring.cloud.cluster.hazelcast.config-location` to tell location of a
+Hazelcast xml configuration file. `config-location` is a normal spring
+`Resource`.
+

--- a/docs/src/main/asciidoc/spring-cloud-cluster.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-cluster.adoc
@@ -1,3 +1,5 @@
 = Spring Cloud Cluster
 
 include::intro.adoc[]
+
+include::leaderelection.adoc[]

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
 		<module>spring-cloud-cluster-core</module>
 		<module>spring-cloud-cluster-zookeeper</module>
 		<module>spring-cloud-cluster-hazelcast</module>
+		<module>spring-cloud-cluster-autoconfigure</module>
 		<module>docs</module>
 	</modules>
 
@@ -45,6 +46,16 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-cluster-core</artifactId>
+				<version>${spring-cloud.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-cluster-zookeeper</artifactId>
+				<version>${spring-cloud.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-cluster-hazelcast</artifactId>
 				<version>${spring-cloud.version}</version>
 			</dependency>
 			<dependency>

--- a/spring-cloud-cluster-autoconfigure/pom.xml
+++ b/spring-cloud-cluster-autoconfigure/pom.xml
@@ -4,11 +4,11 @@
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>spring-cloud-cluster-core</artifactId>
+	<artifactId>spring-cloud-cluster-autoconfigure</artifactId>
 	<packaging>jar</packaging>
 
-	<name>spring-cloud-cluster-core</name>
-	<description>Spring Cloud Cluster Core</description>
+	<name>spring-cloud-cluster-autoconfigure</name>
+	<description>Spring Cloud Cluster AutoConfigure</description>
 
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
@@ -19,12 +19,14 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-context</artifactId>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-cluster-zookeeper</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-cluster-hazelcast</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -32,8 +34,13 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-test</artifactId>
+			<groupId>org.apache.curator</groupId>
+			<artifactId>curator-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/autoconfigure/leader/HazelcastLeaderAutoConfiguration.java
+++ b/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/autoconfigure/leader/HazelcastLeaderAutoConfiguration.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.autoconfigure.leader;
+
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.cluster.hazelcast.leader.HazelcastProperties;
+import org.springframework.cloud.cluster.hazelcast.leader.LeaderInitiator;
+import org.springframework.cloud.cluster.leader.Candidate;
+import org.springframework.cloud.cluster.leader.DefaultCandidate;
+import org.springframework.cloud.cluster.leader.LeaderElectionProperties;
+import org.springframework.cloud.cluster.leader.event.LeaderEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.XmlConfigBuilder;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+
+/**
+ * Auto-configuration for hazelcast leader election.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+@Configuration
+@ConditionalOnClass(LeaderInitiator.class)
+@ConditionalOnProperty(value = { "spring.cloud.cluster.leader.enabled",
+		"spring.cloud.cluster.hazelcast.leader.enabled" }, matchIfMissing = true)
+@ConditionalOnMissingBean(name = "hazelcastLeaderInitiator")
+@EnableConfigurationProperties({ LeaderElectionProperties.class,
+		HazelcastProperties.class })
+@AutoConfigureAfter(LeaderAutoConfiguration.class)
+public class HazelcastLeaderAutoConfiguration {
+
+	@Autowired
+	private LeaderElectionProperties lep;
+
+	@Autowired
+	private HazelcastProperties hp;
+
+	@Autowired
+	private LeaderEventPublisher publisher;
+
+	@Bean
+	public Candidate hazelcastLeaderCandidate() {
+		return new DefaultCandidate(lep.getId(), lep.getRole());
+	}
+
+	@Bean
+	public HazelcastInstance hazelcastInstance() {
+		return Hazelcast.newHazelcastInstance(hazelcastConfig());
+	}
+
+	@Bean
+	public LeaderInitiator hazelcastLeaderInitiator() {
+		LeaderInitiator initiator = new LeaderInitiator(hazelcastInstance(),
+				hazelcastLeaderCandidate());
+		initiator.setLeaderEventPublisher(publisher);
+		return initiator;
+	}
+
+	@Bean
+	public Config hazelcastConfig() {
+		Resource location = hp.getConfigLocation();
+		if (location != null && location.exists()) {
+			try {
+				return new XmlConfigBuilder(hp.getConfigLocation()
+						.getInputStream()).build();
+			} catch (IOException e) {
+				throw new IllegalArgumentException(
+						"Unable to use config location " + location, e);
+			}
+		} else {
+			return new Config();
+		}
+	}
+
+}

--- a/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/autoconfigure/leader/LeaderAutoConfiguration.java
+++ b/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/autoconfigure/leader/LeaderAutoConfiguration.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.autoconfigure.leader;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.cluster.leader.event.LeaderEventPublisher;
+import org.springframework.cloud.cluster.leader.event.LeaderEventPublisherConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Auto-configuration for generic leader election components.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+@Configuration
+@ConditionalOnClass(LeaderEventPublisher.class)
+@ConditionalOnProperty(value = { "spring.cloud.cluster.leader.enabled" }, matchIfMissing = true)
+@Import(LeaderEventPublisherConfiguration.class)
+public class LeaderAutoConfiguration {
+}

--- a/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/autoconfigure/leader/ZookeeperLeaderAutoConfiguration.java
+++ b/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/autoconfigure/leader/ZookeeperLeaderAutoConfiguration.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.autoconfigure.leader;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.cluster.leader.Candidate;
+import org.springframework.cloud.cluster.leader.DefaultCandidate;
+import org.springframework.cloud.cluster.leader.LeaderElectionProperties;
+import org.springframework.cloud.cluster.leader.event.LeaderEventPublisher;
+import org.springframework.cloud.cluster.zk.leader.LeaderInitiator;
+import org.springframework.cloud.cluster.zk.leader.ZookeeperProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Auto-configuration for zookeeper leader election.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+@Configuration
+@ConditionalOnClass(LeaderInitiator.class)
+@ConditionalOnProperty(value = { "spring.cloud.cluster.zookeeper.leader.enabled",
+		"spring.cloud.cluster.leader.enabled" }, matchIfMissing = true)
+@ConditionalOnMissingBean(name = "zookeeperLeaderInitiator")
+@EnableConfigurationProperties({ LeaderElectionProperties.class,
+		ZookeeperProperties.class })
+@AutoConfigureAfter(LeaderAutoConfiguration.class)
+public class ZookeeperLeaderAutoConfiguration {
+
+	@Autowired
+	private LeaderElectionProperties lep;
+
+	@Autowired
+	private ZookeeperProperties zkp;
+
+	@Autowired
+	private LeaderEventPublisher publisher;
+
+	@Bean
+	public Candidate zookeeperLeaderCandidate() {
+		return new DefaultCandidate(lep.getId(), lep.getRole());
+	}
+
+	@Bean
+	public CuratorFramework zookeeperLeaderCuratorClient() throws Exception {
+		CuratorFramework client = CuratorFrameworkFactory.builder()
+				.defaultData(new byte[0])
+				.retryPolicy(new ExponentialBackoffRetry(1000, 3))
+				.connectString(zkp.getConnect()).build();
+		return client;
+	}
+
+	@Bean
+	public LeaderInitiator zookeeperLeaderInitiator() throws Exception {
+		LeaderInitiator initiator = new LeaderInitiator(zookeeperLeaderCuratorClient(),
+				zookeeperLeaderCandidate(), zkp.getNamespace());
+		initiator.setLeaderEventPublisher(publisher);
+		return initiator;
+	}
+
+}

--- a/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/autoconfigure/leader/ZookeeperLeaderAutoConfiguration.java
+++ b/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/autoconfigure/leader/ZookeeperLeaderAutoConfiguration.java
@@ -63,7 +63,7 @@ public class ZookeeperLeaderAutoConfiguration {
 		return new DefaultCandidate(lep.getId(), lep.getRole());
 	}
 
-	@Bean
+	@Bean(initMethod = "start", destroyMethod = "close")
 	public CuratorFramework zookeeperLeaderCuratorClient() throws Exception {
 		CuratorFramework client = CuratorFrameworkFactory.builder()
 				.defaultData(new byte[0])

--- a/spring-cloud-cluster-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-cluster-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,4 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.springframework.cloud.autoconfigure.leader.LeaderAutoConfiguration,\
+org.springframework.cloud.autoconfigure.leader.ZookeeperLeaderAutoConfiguration,\
+org.springframework.cloud.autoconfigure.leader.HazelcastLeaderAutoConfiguration

--- a/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/autoconfigure/leader/AbstractLeaderAutoConfigurationTests.java
+++ b/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/autoconfigure/leader/AbstractLeaderAutoConfigurationTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.autoconfigure.leader;
+
+import java.io.IOException;
+
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Before;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+/**
+ * Shared stuff for leader auto-configuration tests.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public class AbstractLeaderAutoConfigurationTests {
+
+	protected AnnotationConfigApplicationContext context;
+	
+	protected ZookeeperTestingServerWrapper zookeeper;
+
+	@Before
+	public void setup() throws Exception {
+		zookeeper = setupZookeeperTestingServer();
+	}
+	
+	@After
+	public void close() {
+		if (context != null) {
+			context.close();
+		}
+		if (zookeeper != null) {
+			try {
+				zookeeper.destroy();
+			} catch (Exception e) {
+			}
+			zookeeper = null;
+		}
+	}
+	
+	protected ZookeeperTestingServerWrapper setupZookeeperTestingServer() throws Exception {
+		return null;
+	}
+
+	static class ZookeeperTestingServerWrapper implements DisposableBean {
+
+		TestingServer testingServer;
+
+		public ZookeeperTestingServerWrapper() throws Exception {
+			this.testingServer = new TestingServer(true);
+		}
+
+		@Override
+		public void destroy() throws Exception {
+			try {
+				testingServer.close();
+			}
+			catch (IOException e) {
+			}
+		}
+
+		public int getPort() {
+			return testingServer.getPort();
+		}
+
+	}
+	
+}

--- a/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/autoconfigure/leader/AbstractLeaderAutoConfigurationTests.java
+++ b/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/autoconfigure/leader/AbstractLeaderAutoConfigurationTests.java
@@ -29,7 +29,7 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
  * @author Janne Valkealahti
  *
  */
-public class AbstractLeaderAutoConfigurationTests {
+public abstract class AbstractLeaderAutoConfigurationTests {
 
 	protected AnnotationConfigApplicationContext context;
 	
@@ -38,6 +38,7 @@ public class AbstractLeaderAutoConfigurationTests {
 	@Before
 	public void setup() throws Exception {
 		zookeeper = setupZookeeperTestingServer();
+		context = setupContext();
 	}
 	
 	@After
@@ -56,6 +57,10 @@ public class AbstractLeaderAutoConfigurationTests {
 	
 	protected ZookeeperTestingServerWrapper setupZookeeperTestingServer() throws Exception {
 		return null;
+	}
+	
+	protected AnnotationConfigApplicationContext setupContext() {
+		return new AnnotationConfigApplicationContext();
 	}
 
 	static class ZookeeperTestingServerWrapper implements DisposableBean {

--- a/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/autoconfigure/leader/HazelcastLeaderAutoConfigurationTests.java
+++ b/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/autoconfigure/leader/HazelcastLeaderAutoConfigurationTests.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.autoconfigure.leader;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.hazelcast.config.Config;
+
+/**
+ * Tests for {@link HazelcastLeaderAutoConfiguration}.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public class HazelcastLeaderAutoConfigurationTests extends AbstractLeaderAutoConfigurationTests {
+
+	@Test
+	public void testDefaults() throws Exception {
+		context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context);
+		context.register(LeaderAutoConfiguration.class, HazelcastLeaderAutoConfiguration.class);
+		context.refresh();
+		
+		assertThat(context.containsBean("hazelcastLeaderInitiator"), is(true));
+		assertThat(context.containsBean("hazelcastLeaderCandidate"), is(true));
+	}
+
+	@Test
+	public void testDisabled() throws Exception {
+		context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.cloud.cluster.hazelcast.leader.enabled:false");
+		context.register(LeaderAutoConfiguration.class, HazelcastLeaderAutoConfiguration.class);
+		context.refresh();
+		
+		assertThat(context.containsBean("hazelcastLeaderInitiator"), is(false));
+		assertThat(context.containsBean("hazelcastLeaderCandidate"), is(false));
+	}
+	
+	@Test
+	public void testGlobalLeaderDisabled() throws Exception {
+		context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils
+				.addEnvironment(
+						this.context,
+						"spring.cloud.cluster.leader.enabled:false",
+						"spring.cloud.cluster.hazelcast.leader.enabled:true");
+		context.register(LeaderAutoConfiguration.class, HazelcastLeaderAutoConfiguration.class);
+		context.refresh();
+		
+		assertThat(context.containsBean("hazelcastLeaderInitiator"), is(false));
+		assertThat(context.containsBean("hazelcastLeaderCandidate"), is(false));
+	}
+	
+	@Test
+	public void testEnabled() throws Exception {
+		context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils
+				.addEnvironment(
+						this.context,
+						"spring.cloud.cluster.hazelcast.leader.enabled:true");
+		context.register(LeaderAutoConfiguration.class, HazelcastLeaderAutoConfiguration.class);
+		context.refresh();
+		
+		assertThat(context.containsBean("hazelcastLeaderInitiator"), is(true));
+		assertThat(context.containsBean("hazelcastLeaderCandidate"), is(true));
+	}
+	
+	@Test
+	public void testOverrideConfig() throws Exception {
+		context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context);
+		context.register(LeaderAutoConfiguration.class, HazelcastLeaderAutoConfiguration.class, OverrideConfig.class);
+		context.refresh();
+		
+		Config config = context.getBean("hazelcastConfig", Config.class);
+		assertThat(config, notNullValue());
+		assertThat(config.getProperty("foo"), is("bar"));
+		assertThat(config.getProperty("bar"), nullValue());
+		
+		assertThat(context.containsBean("hazelcastLeaderInitiator"), is(true));
+		assertThat(context.containsBean("hazelcastLeaderCandidate"), is(true));
+	}
+
+	@Test
+	public void testXmlConfig() throws Exception {
+		context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context,
+				"spring.cloud.cluster.hazelcast.config-location:classpath:/foobar.xml");
+		context.register(LeaderAutoConfiguration.class, HazelcastLeaderAutoConfiguration.class);
+		context.refresh();
+		
+		Config config = context.getBean("hazelcastConfig", Config.class);
+		assertThat(config, notNullValue());
+		assertThat(config.getProperty("foo"), is("bar"));
+		assertThat(config.getProperty("bar"), is("foo"));
+		
+		assertThat(context.containsBean("hazelcastLeaderInitiator"), is(true));
+		assertThat(context.containsBean("hazelcastLeaderCandidate"), is(true));
+	}
+	
+	@Configuration
+	protected static class OverrideConfig {
+		
+		@Bean
+		public Config hazelcastConfig() {
+			Config config = new Config();
+			config.setProperty("foo", "bar");
+			return config;
+		}
+		
+	}
+	
+}

--- a/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/autoconfigure/leader/HazelcastLeaderAutoConfigurationTests.java
+++ b/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/autoconfigure/leader/HazelcastLeaderAutoConfigurationTests.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
 import org.springframework.boot.test.EnvironmentTestUtils;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -38,7 +37,6 @@ public class HazelcastLeaderAutoConfigurationTests extends AbstractLeaderAutoCon
 
 	@Test
 	public void testDefaults() throws Exception {
-		context = new AnnotationConfigApplicationContext();
 		EnvironmentTestUtils.addEnvironment(this.context);
 		context.register(LeaderAutoConfiguration.class, HazelcastLeaderAutoConfiguration.class);
 		context.refresh();
@@ -49,7 +47,6 @@ public class HazelcastLeaderAutoConfigurationTests extends AbstractLeaderAutoCon
 
 	@Test
 	public void testDisabled() throws Exception {
-		context = new AnnotationConfigApplicationContext();
 		EnvironmentTestUtils.addEnvironment(this.context,
 				"spring.cloud.cluster.hazelcast.leader.enabled:false");
 		context.register(LeaderAutoConfiguration.class, HazelcastLeaderAutoConfiguration.class);
@@ -61,7 +58,6 @@ public class HazelcastLeaderAutoConfigurationTests extends AbstractLeaderAutoCon
 	
 	@Test
 	public void testGlobalLeaderDisabled() throws Exception {
-		context = new AnnotationConfigApplicationContext();
 		EnvironmentTestUtils
 				.addEnvironment(
 						this.context,
@@ -76,7 +72,6 @@ public class HazelcastLeaderAutoConfigurationTests extends AbstractLeaderAutoCon
 	
 	@Test
 	public void testEnabled() throws Exception {
-		context = new AnnotationConfigApplicationContext();
 		EnvironmentTestUtils
 				.addEnvironment(
 						this.context,
@@ -90,7 +85,6 @@ public class HazelcastLeaderAutoConfigurationTests extends AbstractLeaderAutoCon
 	
 	@Test
 	public void testOverrideConfig() throws Exception {
-		context = new AnnotationConfigApplicationContext();
 		EnvironmentTestUtils.addEnvironment(this.context);
 		context.register(LeaderAutoConfiguration.class, HazelcastLeaderAutoConfiguration.class, OverrideConfig.class);
 		context.refresh();
@@ -106,7 +100,6 @@ public class HazelcastLeaderAutoConfigurationTests extends AbstractLeaderAutoCon
 
 	@Test
 	public void testXmlConfig() throws Exception {
-		context = new AnnotationConfigApplicationContext();
 		EnvironmentTestUtils.addEnvironment(this.context,
 				"spring.cloud.cluster.hazelcast.config-location:classpath:/foobar.xml");
 		context.register(LeaderAutoConfiguration.class, HazelcastLeaderAutoConfiguration.class);

--- a/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/autoconfigure/leader/LeaderAutoConfigurationTests.java
+++ b/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/autoconfigure/leader/LeaderAutoConfigurationTests.java
@@ -23,7 +23,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.EnvironmentTestUtils;
 import org.springframework.cloud.cluster.leader.Candidate;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 /**
  * Tests for common leadership concepts.
@@ -40,7 +39,6 @@ public class LeaderAutoConfigurationTests extends AbstractLeaderAutoConfiguratio
 
 	@Test
 	public void testAutowireSingleZookeeperCandidate() {
-		context = new AnnotationConfigApplicationContext();
 		EnvironmentTestUtils.addEnvironment(this.context);
 		context.register(LeaderAutoConfiguration.class, ZookeeperLeaderAutoConfiguration.class, Config1.class);
 		context.refresh();
@@ -52,7 +50,6 @@ public class LeaderAutoConfigurationTests extends AbstractLeaderAutoConfiguratio
 
 	@Test
 	public void testAutowireSingleHazelcastCandidate() {
-		context = new AnnotationConfigApplicationContext();
 		EnvironmentTestUtils.addEnvironment(this.context);
 		context.register(LeaderAutoConfiguration.class, HazelcastLeaderAutoConfiguration.class, Config1.class);
 		context.refresh();
@@ -64,7 +61,6 @@ public class LeaderAutoConfigurationTests extends AbstractLeaderAutoConfiguratio
 
 	@Test
 	public void testAutowireMultipleCandidates() {
-		context = new AnnotationConfigApplicationContext();
 		EnvironmentTestUtils.addEnvironment(this.context);
 		context.register(LeaderAutoConfiguration.class,
 				ZookeeperLeaderAutoConfiguration.class,

--- a/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/autoconfigure/leader/LeaderAutoConfigurationTests.java
+++ b/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/autoconfigure/leader/LeaderAutoConfigurationTests.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.autoconfigure.leader;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.cloud.cluster.leader.Candidate;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+/**
+ * Tests for common leadership concepts.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public class LeaderAutoConfigurationTests extends AbstractLeaderAutoConfigurationTests {
+
+	@Override
+	protected ZookeeperTestingServerWrapper setupZookeeperTestingServer() throws Exception {
+		return new ZookeeperTestingServerWrapper();
+	}
+
+	@Test
+	public void testAutowireSingleZookeeperCandidate() {
+		context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context);
+		context.register(LeaderAutoConfiguration.class, ZookeeperLeaderAutoConfiguration.class, Config1.class);
+		context.refresh();
+		
+		Config1 config1 = context.getBean(Config1.class);
+		assertThat(config1, notNullValue());
+		assertThat(config1.candidate, notNullValue());
+	}
+
+	@Test
+	public void testAutowireSingleHazelcastCandidate() {
+		context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context);
+		context.register(LeaderAutoConfiguration.class, HazelcastLeaderAutoConfiguration.class, Config1.class);
+		context.refresh();
+		
+		Config1 config1 = context.getBean(Config1.class);
+		assertThat(config1, notNullValue());
+		assertThat(config1.candidate, notNullValue());		
+	}
+
+	@Test
+	public void testAutowireMultipleCandidates() {
+		context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context);
+		context.register(LeaderAutoConfiguration.class,
+				ZookeeperLeaderAutoConfiguration.class,
+				HazelcastLeaderAutoConfiguration.class, Config2.class);
+		context.refresh();
+		
+		Config2 config2 = context.getBean(Config2.class);
+		assertThat(config2, notNullValue());
+		assertThat(config2.zookeeperLeaderCandidate, notNullValue());		
+		assertThat(config2.hazelcastLeaderCandidate, notNullValue());		
+	}
+	
+	static class Config1 {
+		
+		@Autowired
+		Candidate candidate;
+	}
+
+	static class Config2 {
+		
+		@Autowired
+		@Qualifier("zookeeperLeaderCandidate")
+		Candidate zookeeperLeaderCandidate;
+		
+		@Autowired
+		@Qualifier("hazelcastLeaderCandidate")
+		Candidate hazelcastLeaderCandidate;
+	}
+	
+}

--- a/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/autoconfigure/leader/ZookeeperLeaderAutoConfigurationTests.java
+++ b/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/autoconfigure/leader/ZookeeperLeaderAutoConfigurationTests.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.autoconfigure.leader;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+/**
+ * Tests for {@link ZookeeperLeaderAutoConfiguration}.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public class ZookeeperLeaderAutoConfigurationTests extends AbstractLeaderAutoConfigurationTests {
+
+	@Override
+	protected ZookeeperTestingServerWrapper setupZookeeperTestingServer() throws Exception {
+		return new ZookeeperTestingServerWrapper();
+	}
+	
+	@Test
+	public void testDefaults() throws Exception {
+		context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(this.context);
+		context.register(LeaderAutoConfiguration.class, ZookeeperLeaderAutoConfiguration.class);
+		context.refresh();
+		
+		assertThat(context.containsBean("zookeeperLeaderInitiator"), is(true));
+		assertThat(context.containsBean("zookeeperLeaderCandidate"), is(true));
+	}
+
+	@Test
+	public void testEnabled() throws Exception {
+		context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils
+				.addEnvironment(
+						this.context,
+						"spring.cloud.cluster.zookeeper.leader.enabled:true",
+						"spring.cloud.cluster.zookeeper.connect:localhost:" + zookeeper.getPort());
+		context.register(LeaderAutoConfiguration.class, ZookeeperLeaderAutoConfiguration.class);
+		context.refresh();
+		
+		assertThat(context.containsBean("zookeeperLeaderInitiator"), is(true));
+		assertThat(context.containsBean("zookeeperLeaderCandidate"), is(true));
+	}
+
+	@Test
+	public void testDisabled() throws Exception {
+		context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils
+				.addEnvironment(
+						this.context,
+						"spring.cloud.cluster.zookeeper.leader.enabled:false");
+		context.register(LeaderAutoConfiguration.class, ZookeeperLeaderAutoConfiguration.class);
+		context.refresh();
+		
+		assertThat(context.containsBean("zookeeperLeaderInitiator"), is(false));
+		assertThat(context.containsBean("zookeeperLeaderCandidate"), is(false));
+	}
+
+	@Test
+	public void testGlobalLeaderDisabled() throws Exception {
+		context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils
+				.addEnvironment(
+						this.context,
+						"spring.cloud.cluster.leader.enabled:false",
+						"spring.cloud.cluster.zookeeper.leader.enabled:true");
+		context.register(LeaderAutoConfiguration.class, ZookeeperLeaderAutoConfiguration.class);
+		context.refresh();
+		
+		assertThat(context.containsBean("zookeeperLeaderInitiator"), is(false));
+		assertThat(context.containsBean("zookeeperLeaderCandidate"), is(false));
+	}
+
+	@Test
+	public void testGlobalLeaderDisabledZkEnabled() throws Exception {
+		context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils
+				.addEnvironment(
+						this.context,
+						"spring.cloud.cluster.leader.enabled:false");
+		context.register(LeaderAutoConfiguration.class, ZookeeperLeaderAutoConfiguration.class);
+		context.refresh();
+		
+		assertThat(context.containsBean("zookeeperLeaderInitiator"), is(false));
+		assertThat(context.containsBean("zookeeperLeaderCandidate"), is(false));
+	}
+	
+}

--- a/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/autoconfigure/leader/ZookeeperLeaderAutoConfigurationTests.java
+++ b/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/autoconfigure/leader/ZookeeperLeaderAutoConfigurationTests.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
 import org.springframework.boot.test.EnvironmentTestUtils;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 /**
  * Tests for {@link ZookeeperLeaderAutoConfiguration}.
@@ -37,7 +36,6 @@ public class ZookeeperLeaderAutoConfigurationTests extends AbstractLeaderAutoCon
 	
 	@Test
 	public void testDefaults() throws Exception {
-		context = new AnnotationConfigApplicationContext();
 		EnvironmentTestUtils.addEnvironment(this.context);
 		context.register(LeaderAutoConfiguration.class, ZookeeperLeaderAutoConfiguration.class);
 		context.refresh();
@@ -48,7 +46,6 @@ public class ZookeeperLeaderAutoConfigurationTests extends AbstractLeaderAutoCon
 
 	@Test
 	public void testEnabled() throws Exception {
-		context = new AnnotationConfigApplicationContext();
 		EnvironmentTestUtils
 				.addEnvironment(
 						this.context,
@@ -63,7 +60,6 @@ public class ZookeeperLeaderAutoConfigurationTests extends AbstractLeaderAutoCon
 
 	@Test
 	public void testDisabled() throws Exception {
-		context = new AnnotationConfigApplicationContext();
 		EnvironmentTestUtils
 				.addEnvironment(
 						this.context,
@@ -77,7 +73,6 @@ public class ZookeeperLeaderAutoConfigurationTests extends AbstractLeaderAutoCon
 
 	@Test
 	public void testGlobalLeaderDisabled() throws Exception {
-		context = new AnnotationConfigApplicationContext();
 		EnvironmentTestUtils
 				.addEnvironment(
 						this.context,
@@ -92,7 +87,6 @@ public class ZookeeperLeaderAutoConfigurationTests extends AbstractLeaderAutoCon
 
 	@Test
 	public void testGlobalLeaderDisabledZkEnabled() throws Exception {
-		context = new AnnotationConfigApplicationContext();
 		EnvironmentTestUtils
 				.addEnvironment(
 						this.context,

--- a/spring-cloud-cluster-autoconfigure/src/test/resources/foobar.xml
+++ b/spring-cloud-cluster-autoconfigure/src/test/resources/foobar.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast
+	xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.4.xsd"
+	xmlns="http://www.hazelcast.com/schema/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+	<properties>
+		<property name="foo">bar</property>
+		<property name="bar">foo</property>
+	</properties>
+
+</hazelcast>

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/AbstractCandidate.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/AbstractCandidate.java
@@ -17,6 +17,8 @@ package org.springframework.cloud.cluster.leader;
 
 import java.util.UUID;
 
+import org.springframework.util.StringUtils;
+
 /**
  * Base implementation of a {@link Candidate}.
  * 
@@ -31,13 +33,22 @@ public abstract class AbstractCandidate implements Candidate {
 	
 	private final String role;
 	
+	/**
+	 * Instantiate a abstract candidate.
+	 */
 	public AbstractCandidate() {
-		this(UUID.randomUUID().toString(), DEFAULT_ROLE);
+		this(null, null);
 	}
 
+	/**
+	 * Instantiate a abstract candidate.
+	 * 
+	 * @param id the identifier
+	 * @param role the role
+	 */
 	public AbstractCandidate(String id, String role) {
-		this.id = id;
-		this.role = role;
+		this.id = StringUtils.hasText(id) ? id : UUID.randomUUID().toString();
+		this.role = StringUtils.hasText(role) ? role : DEFAULT_ROLE;
 	}
 
 	@Override

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/DefaultCandidate.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/DefaultCandidate.java
@@ -28,10 +28,19 @@ public class DefaultCandidate extends AbstractCandidate {
 
 	private volatile Context leaderContext;
 
+	/**
+	 * Instantiate a default candidate.
+	 */
 	public DefaultCandidate() {
 		super();
 	}
 
+	/**
+	 * Instantiate a default candidate.
+	 * 
+	 * @param id the identifier
+	 * @param role the role
+	 */
 	public DefaultCandidate(String id, String role) {
 		super(id, role);
 	}
@@ -48,10 +57,15 @@ public class DefaultCandidate extends AbstractCandidate {
 	}
 
 	/**
-	 * Voluntarily yield leadership if held.
+	 * Voluntarily yield leadership if held. If leader context is not
+	 * yet known this method does nothing. Leader context becomes available
+	 * only after {@link #onGranted(Context)} method is called by the
+	 * leader initiator.
 	 */
 	public void yieldLeadership() {
-		leaderContext.yield();
+		if (leaderContext != null) {
+			leaderContext.yield();			
+		}
 	}
 
 	@Override

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/LeaderElectionProperties.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/LeaderElectionProperties.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.leader;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Generic configuration properties for leader election.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+@ConfigurationProperties(value = "spring.cloud.cluster.leader")
+public class LeaderElectionProperties {
+
+	/** if leader election is enabled globally. */
+	private boolean enabled = true;
+	
+	/** leader election candidate identifier. */
+	private String id;
+	
+	/** leader election candidate role. */
+	private String role;
+	
+	public boolean isEnabled() {
+		return enabled;
+	}
+	
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+	
+	public String getId() {
+		return id;
+	}
+	
+	public void setId(String id) {
+		this.id = id;
+	}
+	
+	public String getRole() {
+		return role;
+	}
+	
+	public void setRole(String role) {
+		this.role = role;
+	}
+	
+}

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/AbstractLeaderEvent.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/AbstractLeaderEvent.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.leader.event;
+
+import org.springframework.cloud.cluster.leader.Context;
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * Base {@link ApplicationEvent} class for leader based events. All custom event
+ * classes should be derived from this class.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@SuppressWarnings("serial")
+public abstract class AbstractLeaderEvent extends ApplicationEvent {
+
+	private Context context;
+	
+	/**
+	 * Create a new ApplicationEvent.
+	 *
+	 * @param source the component that published the event (never {@code null})
+	 */
+	public AbstractLeaderEvent(Object source) {
+		super(source);
+	}
+
+	/**
+	 * Create a new ApplicationEvent.
+	 *
+	 * @param source the component that published the event (never {@code null})
+	 * @param context the context associated with this event
+	 */
+	public AbstractLeaderEvent(Object source, Context context) {
+		super(source);
+		this.context = context;
+	}
+
+	/**
+	 * Gets the {@link Context} associated with this event.
+	 * 
+	 * @return the context
+	 */
+	public Context getContext() {
+		return context;
+	}
+
+	@Override
+	public String toString() {
+		return "AbstractLeaderEvent [context=" + context + ", source=" + source
+				+ "]";
+	}
+
+}

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/DefaultLeaderEventPublisher.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/DefaultLeaderEventPublisher.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.leader.event;
+
+import org.springframework.cloud.cluster.leader.Context;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
+
+/**
+ * Default implementation of {@link LeaderEventPublisher}.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public class DefaultLeaderEventPublisher implements LeaderEventPublisher, ApplicationEventPublisherAware {
+
+	private ApplicationEventPublisher applicationEventPublisher;
+
+	/**
+	 * Instantiates a new leader event publisher.
+	 */
+	public DefaultLeaderEventPublisher() {
+	}
+
+	/**
+	 * Instantiates a new leader event publisher.
+	 * 
+	 * @param applicationEventPublisher the application event publisher
+	 */
+	public DefaultLeaderEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+		this.applicationEventPublisher = applicationEventPublisher;
+	}
+	
+	@Override
+	public void publishOnGranted(Object source, Context context) {
+		if (applicationEventPublisher != null) {
+			applicationEventPublisher.publishEvent(new OnGrantedEvent(source, context));
+		}
+	}
+
+	@Override
+	public void publishOnRevoked(Object source, Context context) {
+		if (applicationEventPublisher != null) {
+			applicationEventPublisher.publishEvent(new OnRevokedEvent(source, context));
+		}
+	}
+
+	@Override
+	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+		this.applicationEventPublisher = applicationEventPublisher;
+	}
+	
+}

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/LeaderEventPublisher.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/LeaderEventPublisher.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.leader.event;
+
+import org.springframework.cloud.cluster.leader.Context;
+
+/**
+ * Interface for publishing leader based application events.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public interface LeaderEventPublisher {
+
+	/**
+	 * Publish a granted event.
+	 * 
+	 * @param source the component generated this event
+	 * @param context the context associated with event
+	 */
+	void publishOnGranted(Object source, Context context);
+
+	/**
+	 * Publish a revoked event.
+	 * 
+	 * @param source the component generated this event
+	 * @param context the context associated with event
+	 */
+	void publishOnRevoked(Object source, Context context);
+	
+}

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/LeaderEventPublisherConfiguration.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/LeaderEventPublisherConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.leader.event;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration for common {@link LeaderEventPublisher}.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+@Configuration
+public class LeaderEventPublisherConfiguration {
+
+	@Bean
+	public LeaderEventPublisher leaderEventPublisher() {
+		return new DefaultLeaderEventPublisher();
+	}
+	
+}

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/LoggingListener.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/LoggingListener.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.leader.event;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationListener;
+import org.springframework.util.StringUtils;
+
+/**
+ * Simple {@link ApplicationListener} which logs all events
+ * based on {@link AbstractLeaderEvent} using a log level
+ * set during the construction.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class LoggingListener implements ApplicationListener<AbstractLeaderEvent> {
+
+	private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+	/** Internal enums to match the log level */
+	private static enum Level {
+		ERROR, WARN, INFO, DEBUG, TRACE
+	}
+
+	/** Level to use */
+	private final Level level;
+
+	/**
+	 * Constructs Logger listener with debug level.
+	 */
+	public LoggingListener() {
+		level = Level.DEBUG;
+	}
+
+	/**
+	 * Constructs Logger listener with given level.
+	 *
+	 * @param level the level string
+	 */
+	public LoggingListener(String level) {
+		try {
+			this.level = Level.valueOf(level.toUpperCase());
+		}
+		catch (IllegalArgumentException e) {
+			throw new IllegalArgumentException("Invalid log level '" + level
+					+ "'. The (case-insensitive) supported values are: "
+					+ StringUtils.arrayToCommaDelimitedString(Level.values()));
+		}
+	}
+
+	@Override
+	public void onApplicationEvent(AbstractLeaderEvent event) {
+		switch (this.level) {
+		case ERROR:
+			if (logger.isErrorEnabled()) {
+				logger.error(event.toString());
+			}
+			break;
+		case WARN:
+			if (logger.isWarnEnabled()) {
+				logger.warn(event.toString());
+			}
+			break;
+		case INFO:
+			if (logger.isInfoEnabled()) {
+				logger.info(event.toString());
+			}
+			break;
+		case DEBUG:
+			if (logger.isDebugEnabled()) {
+				logger.debug(event.toString());
+			}
+			break;
+		case TRACE:
+			if (logger.isTraceEnabled()) {
+				logger.trace(event.toString());
+			}
+			break;
+		}
+	}
+
+}

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/OnGrantedEvent.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/OnGrantedEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.leader.event;
+
+import org.springframework.cloud.cluster.leader.Context;
+
+/**
+ * Generic event representing that leader has been granted.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@SuppressWarnings("serial")
+public class OnGrantedEvent extends AbstractLeaderEvent {
+
+	/**
+	 * Instantiates a new granted event.
+	 * 
+	 * @param source the component that published the event (never {@code null})
+	 * @param context the context associated with this event
+	 */
+	public OnGrantedEvent(Object source, Context context) {
+		super(source, context);
+	}
+
+}

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/OnRevokedEvent.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/OnRevokedEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.leader.event;
+
+import org.springframework.cloud.cluster.leader.Context;
+
+/**
+ * Generic event representing that leader has been revoked.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@SuppressWarnings("serial")
+public class OnRevokedEvent extends AbstractLeaderEvent {
+
+	/**
+	 * Instantiates a new revoked event.
+	 * 
+	 * @param source the component that published the event (never {@code null})
+	 * @param context the context associated with this event
+	 */
+	public OnRevokedEvent(Object source, Context context) {
+		super(source, context);
+	}
+
+}

--- a/spring-cloud-cluster-hazelcast/pom.xml
+++ b/spring-cloud-cluster-hazelcast/pom.xml
@@ -23,6 +23,11 @@
 			<artifactId>spring-cloud-cluster-core</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<artifactId>hazelcast</artifactId>
 			<groupId>com.hazelcast</groupId>
 		</dependency>

--- a/spring-cloud-cluster-hazelcast/src/main/java/org/springframework/cloud/cluster/hazelcast/leader/HazelcastProperties.java
+++ b/spring-cloud-cluster-hazelcast/src/main/java/org/springframework/cloud/cluster/hazelcast/leader/HazelcastProperties.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.hazelcast.leader;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.io.Resource;
+
+/**
+ * Configuration properties for hazelcast leader election.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+@ConfigurationProperties(value = "spring.cloud.cluster.hazelcast")
+public class HazelcastProperties {
+	
+	/** xml config location for hazelcast configuration. */
+	private Resource configLocation;
+
+	/** hazelcast leader properties. */
+	private HazelcastLeaderProperties leader = new HazelcastLeaderProperties();
+	
+	public Resource getConfigLocation() {
+		return configLocation;
+	}
+	
+	public void setConfigLocation(Resource configLocation) {
+		this.configLocation = configLocation;
+	}
+	
+	public HazelcastLeaderProperties getLeader() {
+		return leader;
+	}
+	
+	public void setLeader(HazelcastLeaderProperties leader) {
+		this.leader = leader;
+	}
+	
+	public static class HazelcastLeaderProperties {
+
+		/** if hazelcast leader election is enabled. */
+		private boolean enabled = true;
+
+		public boolean isEnabled() {
+			return enabled;
+		}
+		
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+	}
+	
+}

--- a/spring-cloud-cluster-hazelcast/src/main/java/org/springframework/cloud/cluster/hazelcast/leader/LeaderInitiator.java
+++ b/spring-cloud-cluster-hazelcast/src/main/java/org/springframework/cloud/cluster/hazelcast/leader/LeaderInitiator.java
@@ -23,15 +23,16 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
-
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.cloud.cluster.leader.Candidate;
 import org.springframework.cloud.cluster.leader.Context;
+import org.springframework.cloud.cluster.leader.event.LeaderEventPublisher;
 import org.springframework.context.Lifecycle;
 import org.springframework.util.Assert;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
 
 /**
  * Bootstrap leadership {@link org.springframework.cloud.cluster.leader.Candidate candidates}
@@ -81,6 +82,9 @@ public class LeaderInitiator implements Lifecycle, InitializingBean, DisposableB
 	 */
 	private volatile boolean running;
 
+	/** Leader event publisher if set */
+	private LeaderEventPublisher leaderEventPublisher;
+	
 	/**
 	 * Construct a {@link LeaderInitiator}.
 	 *
@@ -134,7 +138,16 @@ public class LeaderInitiator implements Lifecycle, InitializingBean, DisposableB
 		stop();
 		executorService.shutdown();
 	}
-
+	
+	/**
+	 * Sets the {@link LeaderEventPublisher}.
+	 * 
+	 * @param leaderEventPublisher the event publisher
+	 */
+	public void setLeaderEventPublisher(LeaderEventPublisher leaderEventPublisher) {
+		this.leaderEventPublisher = leaderEventPublisher;
+	}
+	
 	/**
 	 * Callable that manages the acquisition of Hazelcast locks
 	 * for leadership election.
@@ -154,6 +167,9 @@ public class LeaderInitiator implements Lifecycle, InitializingBean, DisposableB
 					if (locked) {
 						mapLocks.put(role, candidate.getId());
 						candidate.onGranted(context);
+						if (leaderEventPublisher != null) {
+							leaderEventPublisher.publishOnGranted(LeaderInitiator.this, context);
+						}
 						Thread.sleep(Long.MAX_VALUE);
 					}
 				}
@@ -167,6 +183,9 @@ public class LeaderInitiator implements Lifecycle, InitializingBean, DisposableB
 						mapLocks.remove(role);
 						mapLocks.unlock(role);
 						candidate.onRevoked(context);
+						if (leaderEventPublisher != null) {
+							leaderEventPublisher.publishOnRevoked(LeaderInitiator.this, context);
+						}
 						locked = false;
 					}
 				}

--- a/spring-cloud-cluster-zookeeper/pom.xml
+++ b/spring-cloud-cluster-zookeeper/pom.xml
@@ -23,6 +23,11 @@
 			<artifactId>spring-cloud-cluster-core</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.curator</groupId>
 			<artifactId>curator-recipes</artifactId>
 		</dependency>

--- a/spring-cloud-cluster-zookeeper/src/main/java/org/springframework/cloud/cluster/zk/leader/LeaderInitiator.java
+++ b/spring-cloud-cluster-zookeeper/src/main/java/org/springframework/cloud/cluster/zk/leader/LeaderInitiator.java
@@ -65,7 +65,7 @@ public class LeaderInitiator implements Lifecycle, InitializingBean, DisposableB
 	private final String namespace;
 	
 	/** Leader event publisher if set */
-	private LeaderEventPublisher leaderEventPublisher;
+	private volatile LeaderEventPublisher leaderEventPublisher;
 
 	/**
 	 * Construct a {@link LeaderInitiator}.
@@ -120,7 +120,6 @@ public class LeaderInitiator implements Lifecycle, InitializingBean, DisposableB
 	public synchronized void stop() {
 		if (running) {
 			leaderSelector.close();
-			client.close();
 			running = false;
 		}
 	}

--- a/spring-cloud-cluster-zookeeper/src/main/java/org/springframework/cloud/cluster/zk/leader/ZookeeperProperties.java
+++ b/spring-cloud-cluster-zookeeper/src/main/java/org/springframework/cloud/cluster/zk/leader/ZookeeperProperties.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.zk.leader;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for zookeeper leader election.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+@ConfigurationProperties(value = "spring.cloud.cluster.zookeeper")
+public class ZookeeperProperties {
+
+	/** base zookeeper namespace path. */
+	private String namespace;
+	
+	/** connect string for zookeeper. */
+	private String connect = "localhost:2181";
+
+	/** zookeeper leader properties. */
+	private ZookeeperLeaderProperties leader = new ZookeeperLeaderProperties();
+	
+	public String getNamespace() {
+		return namespace;
+	}
+
+	public void setNamespace(String namespace) {
+		this.namespace = namespace;
+	}
+
+	public String getConnect() {
+		return connect;
+	}
+
+	public void setConnect(String connect) {
+		this.connect = connect;
+	}
+	
+	public ZookeeperLeaderProperties getLeader() {
+		return leader;
+	}
+	
+	public void setLeader(ZookeeperLeaderProperties leader) {
+		this.leader = leader;
+	}
+	
+	public static class ZookeeperLeaderProperties {
+
+		/** if zookeeper leader election is enabled. */
+		private boolean enabled = true;
+	
+		public boolean isEnabled() {
+			return enabled;
+		}
+		
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+		
+	}
+
+}


### PR DESCRIPTION
Check docs/src/main/asciidoc/leaderelection.adoc for more info about what we have here. This PR relates to #6 and #7.

- Auto-configuration for both hazelcast and zookeeper.
- Generates boot props metadata.
- Both hazelcast and zookeeper leader election can
  co-exist at a same time to make configuration easier.
  There are flags to disable election for both hazelcast
  and zookeeper or globally.
- Granted and revoked actions are also published as event
  objects via spring context.
- Auto-config happens in its own package
  spring-cloud-cluster-autoconfigure which allows to make
  optional dependencies to all other packages.