### PR TITLE
Add lock system and redis implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
 		<module>spring-cloud-cluster-core</module>
 		<module>spring-cloud-cluster-zookeeper</module>
 		<module>spring-cloud-cluster-hazelcast</module>
+		<module>spring-cloud-cluster-redis</module>
 		<module>spring-cloud-cluster-autoconfigure</module>
 		<module>docs</module>
 	</modules>
@@ -39,6 +40,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.7</java.version>
 		<start-class>org.springframework.cloud.cluster.test.Application</start-class>
+		<skipITs>true</skipITs>
 	</properties>
 
 	<dependencyManagement>
@@ -56,6 +58,11 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-cluster-hazelcast</artifactId>
+				<version>${spring-cloud.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-cluster-redis</artifactId>
 				<version>${spring-cloud.version}</version>
 			</dependency>
 			<dependency>
@@ -80,6 +87,26 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
+
+<build>
+	<plugins>
+		<plugin>
+			<artifactId>maven-failsafe-plugin</artifactId>
+			<configuration>
+				<skipITs>${skipITs}</skipITs>
+			</configuration>
+			<executions>
+				<execution>
+					<phase>package</phase>
+					<goals>
+						<goal>integration-test</goal>
+						<goal>verify</goal>
+					</goals>
+				</execution>
+			</executions>
+		</plugin>
+	</plugins>
+</build>
 
 	<profiles>
 		<profile>

--- a/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/cluster/autoconfigure/leader/HazelcastLeaderAutoConfiguration.java
+++ b/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/cluster/autoconfigure/leader/HazelcastLeaderAutoConfiguration.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.autoconfigure.leader;
+package org.springframework.cloud.cluster.autoconfigure.leader;
 
 import java.io.IOException;
 

--- a/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/cluster/autoconfigure/leader/LeaderAutoConfiguration.java
+++ b/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/cluster/autoconfigure/leader/LeaderAutoConfiguration.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.autoconfigure.leader;
+package org.springframework.cloud.cluster.autoconfigure.leader;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;

--- a/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/cluster/autoconfigure/leader/ZookeeperLeaderAutoConfiguration.java
+++ b/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/cluster/autoconfigure/leader/ZookeeperLeaderAutoConfiguration.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.autoconfigure.leader;
+package org.springframework.cloud.cluster.autoconfigure.leader;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;

--- a/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/cluster/autoconfigure/lock/RedisLockServiceAutoConfiguration.java
+++ b/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/cluster/autoconfigure/lock/RedisLockServiceAutoConfiguration.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.autoconfigure.lock;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.cluster.lock.DistributedLockProperties;
+import org.springframework.cloud.cluster.redis.RedisClusterProperties;
+import org.springframework.cloud.cluster.redis.lock.RedisLockService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+/**
+ * Auto-configuration for {@link RedisLockService}.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+@Configuration
+@ConditionalOnClass(RedisLockService.class)
+@ConditionalOnProperty(value = { "spring.cloud.cluster.redis.lock.enabled",
+		"spring.cloud.cluster.lock.enabled" }, matchIfMissing = true)
+@EnableConfigurationProperties({ DistributedLockProperties.class,
+		RedisClusterProperties.class })
+@ConditionalOnBean(RedisConnectionFactory.class)
+public class RedisLockServiceAutoConfiguration {
+
+	@Autowired
+	private RedisConnectionFactory redisConnectionFactory;
+	
+	@Autowired
+	private DistributedLockProperties distributedLockProperties;
+	
+	@Autowired
+	private RedisClusterProperties redisClusterProperties;
+	
+	@Bean
+	public RedisLockService redisLockService() {
+		String role = distributedLockProperties.getRole();
+		Long expire = redisClusterProperties.getLock().getExpireAfter();				
+		if (role != null && expire != null) {
+			return new RedisLockService(redisConnectionFactory, role, expire);
+		} else if (role != null) {
+			return new RedisLockService(redisConnectionFactory, role);
+		} else if (expire != null) {
+			return new RedisLockService(redisConnectionFactory, expire);
+		} else {
+			return new RedisLockService(redisConnectionFactory);
+		}
+	}
+
+}

--- a/spring-cloud-cluster-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-cluster-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-org.springframework.cloud.autoconfigure.leader.LeaderAutoConfiguration,\
-org.springframework.cloud.autoconfigure.leader.ZookeeperLeaderAutoConfiguration,\
-org.springframework.cloud.autoconfigure.leader.HazelcastLeaderAutoConfiguration
+org.springframework.cloud.cluster.autoconfigure.leader.LeaderAutoConfiguration,\
+org.springframework.cloud.cluster.autoconfigure.leader.ZookeeperLeaderAutoConfiguration,\
+org.springframework.cloud.cluster.autoconfigure.leader.HazelcastLeaderAutoConfiguration,\
+org.springframework.cloud.cluster.autoconfigure.lock.RedisLockServiceAutoConfiguration

--- a/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/TestUtils.java
+++ b/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/TestUtils.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.autoconfigure;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Utils for tests.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public class TestUtils {
+
+	@SuppressWarnings("unchecked")
+	public static <T> T readField(String name, Object target) throws Exception {
+		Field field = null;
+		Class<?> clazz = target.getClass();
+		do {
+			try {
+				field = clazz.getDeclaredField(name);
+			} catch (Exception ex) {
+			}
+
+			clazz = clazz.getSuperclass();
+		} while (field == null && !clazz.equals(Object.class));
+
+		if (field == null)
+			throw new IllegalArgumentException("Cannot find field '" + name + "' in the class hierarchy of "
+					+ target.getClass());
+		field.setAccessible(true);
+		return (T) field.get(target);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> T callMethod(String name, Object target) throws Exception {
+		Class<?> clazz = target.getClass();
+		Method method = ReflectionUtils.findMethod(clazz, name);
+
+		if (method == null)
+			throw new IllegalArgumentException("Cannot find method '" + method + "' in the class hierarchy of "
+					+ target.getClass());
+		method.setAccessible(true);
+		return (T) ReflectionUtils.invokeMethod(method, target);
+	}
+
+	public static void setField(String name, Object target, Object value) throws Exception {
+		Field field = null;
+		Class<?> clazz = target.getClass();
+		do {
+			try {
+				field = clazz.getDeclaredField(name);
+			} catch (Exception ex) {
+			}
+
+			clazz = clazz.getSuperclass();
+		} while (field == null && !clazz.equals(Object.class));
+
+		if (field == null)
+			throw new IllegalArgumentException("Cannot find field '" + name + "' in the class hierarchy of "
+					+ target.getClass());
+		field.setAccessible(true);
+		field.set(target, value);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> T callMethod(String name, Object target, Object[] args, Class<?>[] argsTypes) throws Exception {
+		Class<?> clazz = target.getClass();
+		Method method = ReflectionUtils.findMethod(clazz, name, argsTypes);
+
+		if (method == null)
+			throw new IllegalArgumentException("Cannot find method '" + method + "' in the class hierarchy of "
+					+ target.getClass());
+		method.setAccessible(true);
+		return (T) ReflectionUtils.invokeMethod(method, target, args);
+	}
+	
+}

--- a/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/leader/AbstractLeaderAutoConfigurationTests.java
+++ b/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/leader/AbstractLeaderAutoConfigurationTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.autoconfigure.leader;
+
+import java.io.IOException;
+
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Before;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+/**
+ * Shared stuff for leader auto-configuration tests.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public abstract class AbstractLeaderAutoConfigurationTests {
+
+	protected AnnotationConfigApplicationContext context;
+	
+	protected ZookeeperTestingServerWrapper zookeeper;
+
+	@Before
+	public void setup() throws Exception {
+		zookeeper = setupZookeeperTestingServer();
+		context = setupContext();
+	}
+	
+	@After
+	public void close() {
+		if (context != null) {
+			context.close();
+		}
+		if (zookeeper != null) {
+			try {
+				zookeeper.destroy();
+			} catch (Exception e) {
+			}
+			zookeeper = null;
+		}
+	}
+	
+	protected ZookeeperTestingServerWrapper setupZookeeperTestingServer() throws Exception {
+		return null;
+	}
+	
+	protected AnnotationConfigApplicationContext setupContext() {
+		return new AnnotationConfigApplicationContext();
+	}
+
+	static class ZookeeperTestingServerWrapper implements DisposableBean {
+
+		TestingServer testingServer;
+
+		public ZookeeperTestingServerWrapper() throws Exception {
+			this.testingServer = new TestingServer(true);
+		}
+
+		@Override
+		public void destroy() throws Exception {
+			try {
+				testingServer.close();
+			}
+			catch (IOException e) {
+			}
+		}
+
+		public int getPort() {
+			return testingServer.getPort();
+		}
+
+	}
+	
+}

--- a/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/leader/HazelcastLeaderAutoConfigurationTests.java
+++ b/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/leader/HazelcastLeaderAutoConfigurationTests.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.autoconfigure.leader;
+package org.springframework.cloud.cluster.autoconfigure.leader;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;

--- a/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/leader/LeaderAutoConfigurationTests.java
+++ b/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/leader/LeaderAutoConfigurationTests.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.autoconfigure.leader;
+package org.springframework.cloud.cluster.autoconfigure.leader;
 
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;

--- a/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/leader/ZookeeperLeaderAutoConfigurationTests.java
+++ b/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/leader/ZookeeperLeaderAutoConfigurationTests.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.autoconfigure.leader;
+package org.springframework.cloud.cluster.autoconfigure.leader;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;

--- a/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/lock/AbstractLockAutoConfigurationTests.java
+++ b/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/lock/AbstractLockAutoConfigurationTests.java
@@ -13,31 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.autoconfigure.leader;
+package org.springframework.cloud.cluster.autoconfigure.lock;
 
-import java.io.IOException;
-
-import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Before;
-import org.springframework.beans.factory.DisposableBean;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 /**
- * Shared stuff for leader auto-configuration tests.
+ * Shared stuff for locking auto-configuration tests.
  * 
  * @author Janne Valkealahti
  *
  */
-public abstract class AbstractLeaderAutoConfigurationTests {
+public abstract class AbstractLockAutoConfigurationTests {
 
 	protected AnnotationConfigApplicationContext context;
-	
-	protected ZookeeperTestingServerWrapper zookeeper;
 
 	@Before
-	public void setup() throws Exception {
-		zookeeper = setupZookeeperTestingServer();
+	public void setup() {
 		context = setupContext();
 	}
 	
@@ -46,44 +39,10 @@ public abstract class AbstractLeaderAutoConfigurationTests {
 		if (context != null) {
 			context.close();
 		}
-		if (zookeeper != null) {
-			try {
-				zookeeper.destroy();
-			} catch (Exception e) {
-			}
-			zookeeper = null;
-		}
-	}
-	
-	protected ZookeeperTestingServerWrapper setupZookeeperTestingServer() throws Exception {
-		return null;
 	}
 	
 	protected AnnotationConfigApplicationContext setupContext() {
 		return new AnnotationConfigApplicationContext();
-	}
-
-	static class ZookeeperTestingServerWrapper implements DisposableBean {
-
-		TestingServer testingServer;
-
-		public ZookeeperTestingServerWrapper() throws Exception {
-			this.testingServer = new TestingServer(true);
-		}
-
-		@Override
-		public void destroy() throws Exception {
-			try {
-				testingServer.close();
-			}
-			catch (IOException e) {
-			}
-		}
-
-		public int getPort() {
-			return testingServer.getPort();
-		}
-
 	}
 	
 }

--- a/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/lock/RedisLockServiceAutoConfigurationTests.java
+++ b/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/lock/RedisLockServiceAutoConfigurationTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.autoconfigure.lock;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.redis.RedisAutoConfiguration;
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.cloud.cluster.autoconfigure.TestUtils;
+import org.springframework.cloud.cluster.redis.lock.RedisLockService;
+import org.springframework.integration.redis.util.RedisLockRegistry;
+
+/**
+ * Tests for {@link RedisLockServiceAutoConfiguration}.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public class RedisLockServiceAutoConfigurationTests extends AbstractLockAutoConfigurationTests {
+
+	@Test
+	public void testDefaults() {
+		EnvironmentTestUtils.addEnvironment(this.context);
+		context.register(RedisAutoConfiguration.class, RedisLockServiceAutoConfiguration.class);
+		context.refresh();
+		
+		assertThat(context.containsBean("redisLockService"), is(true));		
+	}
+
+	@Test
+	public void testDisabled() throws Exception {
+		EnvironmentTestUtils
+				.addEnvironment(
+						this.context,
+						"spring.cloud.cluster.redis.lock.enabled:false");
+		context.register(RedisAutoConfiguration.class, RedisLockServiceAutoConfiguration.class);
+		context.refresh();
+		
+		assertThat(context.containsBean("redisLockService"), is(false));
+	}
+
+	@Test
+	public void testGlobalLeaderDisabled() throws Exception {
+		EnvironmentTestUtils
+				.addEnvironment(
+						this.context,
+						"spring.cloud.cluster.lock.enabled:false",
+						"spring.cloud.cluster.redis.lock.enabled:true");
+		context.register(RedisAutoConfiguration.class, RedisLockServiceAutoConfiguration.class);
+		context.refresh();
+		
+		assertThat(context.containsBean("redisLockService"), is(false));
+	}
+
+	@Test
+	public void testChangeRole() throws Exception {
+		EnvironmentTestUtils
+				.addEnvironment(
+						this.context,
+						"spring.cloud.cluster.lock.role:foo");
+		context.register(RedisAutoConfiguration.class, RedisLockServiceAutoConfiguration.class);
+		context.refresh();
+		
+		RedisLockService service = context.getBean(RedisLockService.class);
+		RedisLockRegistry redisLockRegistry = TestUtils.readField("redisLockRegistry", service);
+		String registryKey = TestUtils.readField("registryKey", redisLockRegistry);
+		
+		assertThat(registryKey, is("foo"));
+	}
+
+	@Test
+	public void testChangeTimeout() throws Exception {
+		EnvironmentTestUtils
+				.addEnvironment(
+						this.context,
+						"spring.cloud.cluster.redis.lock.expireAfter:1234");
+		context.register(RedisAutoConfiguration.class, RedisLockServiceAutoConfiguration.class);
+		context.refresh();
+		
+		RedisLockService service = context.getBean(RedisLockService.class);
+		RedisLockRegistry redisLockRegistry = TestUtils.readField("redisLockRegistry", service);
+		String registryKey = TestUtils.readField("registryKey", redisLockRegistry);
+		Long expireAfter = TestUtils.readField("expireAfter", redisLockRegistry);
+		
+		assertThat(registryKey, is(RedisLockService.DEFAULT_REGISTRY_KEY));
+		assertThat(expireAfter, is(1234l));
+	}
+
+}

--- a/spring-cloud-cluster-core/pom.xml
+++ b/spring-cloud-cluster-core/pom.xml
@@ -20,7 +20,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework</groupId>
-			<artifactId>spring-context</artifactId>
+			<artifactId>spring-tx</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -32,8 +32,8 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-test</artifactId>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/DistributedLock.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/DistributedLock.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.lock;
+
+import java.util.concurrent.locks.Lock;
+
+/**
+ * Distributed implementation of a {@link Lock}.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public interface DistributedLock extends Lock {
+
+	/**
+	 * Gets the associated lock key.
+	 * 
+	 * @return associated lock key
+	 */
+	String getLockKey();
+	
+}

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/DistributedLockProperties.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/DistributedLockProperties.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.lock;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Generic configuration properties for distributed locking.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+@ConfigurationProperties(value = "spring.cloud.cluster.lock")
+public class DistributedLockProperties {
+
+	/** if distributed locking is enabled globally. */
+	private boolean enabled = true;
+
+	/** distributed locking role. */
+	private String role;
+	
+	public boolean isEnabled() {
+		return enabled;
+	}
+	
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public String getRole() {
+		return role;
+	}
+	
+	public void setRole(String role) {
+		this.role = role;
+	}
+	
+}

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/LockRegistry.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/LockRegistry.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.lock;
+
+/**
+ * {@code LockRegistry} implementations provide high
+ * level access to obtain {@link DistributedLock}s
+ * from a system using a locking key.
+ * 
+ * <p>Purpose of this interface is to decouple lock
+ * access from their implementing system. Registry may
+ * return locks from different systems while {@link LockService}
+ * is always bound to a one system. Also implementation may
+ * choose to use {@link LockServiceLocator} to find the backing
+ * {@link LockService} implementation.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public interface LockRegistry {
+
+	/**
+	 * Gets a {@link DistributedLock} from a registry.
+	 * 
+	 * @param lockKey the locking key
+	 * @return distributed lock
+	 */
+	DistributedLock get(String lockKey);
+
+}

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/LockService.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/LockService.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.lock;
+
+/**
+ * {@code LockService} implementations provide low
+ * level access to a particular locking service. This
+ * service is always backed by a real locking service
+ * bound to a real distributed system like zookeeper
+ * or redis.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public interface LockService {
+	
+	/**
+	 * Obtains a {@link DistributedLock} from a service. Obtaining
+	 * a lock should not do any locking operations like trying
+	 * a lock. All possible locking actions should be left to a user
+	 * to be executed via {@link DistributedLock}.
+	 * 
+	 * @param lockKey the locking key
+	 * @return distributed lock
+	 */
+	DistributedLock obtain(String lockKey);
+
+}

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/LockServiceLocator.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/LockServiceLocator.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.lock;
+
+/**
+ * Lock service locator defines a contract matching a lock
+ * key to a {@link LockService}.
+ * 
+ * <p>Implementation is free to implement this interface as
+ * it wish. Possible implementation can i.e. choose to locate
+ * different services based on path matching or any other means
+ * which creates a consistent resolving to a service.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public interface LockServiceLocator {
+
+	/**
+	 * Locates a bound {@link LockService} for a locking key.
+	 * 
+	 * <p>Locate algorithm has to be consistent among different
+	 * JVM's meaning that in all cases a locking key has to resolve
+	 * back to same {@link LockService} where {@link DistributedLock}
+	 * either already exists or will exist once it is created.
+	 * 
+	 * @param lockKey the locking key
+	 * @return lock service or null if key is not bound to any service
+	 */
+	LockService locate(String lockKey);
+	
+}

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/LockingException.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/LockingException.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.lock;
+
+import org.springframework.dao.NonTransientDataAccessException;
+
+/**
+ * Generic runtime exception for locking system.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public class LockingException extends NonTransientDataAccessException {
+
+	private static final long serialVersionUID = 285133760957296884L;
+
+	/**
+	 * Instantiates a new locking exception.
+	 *
+	 * @param msg the msg
+	 * @param cause the cause
+	 */
+	public LockingException(String msg, Throwable cause) {
+		super(msg, cause);
+	}
+
+	/**
+	 * Instantiates a new locking exception.
+	 *
+	 * @param msg the msg
+	 */
+	public LockingException(String msg) {
+		super(msg);
+	}
+
+}

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/support/AbstractDistributedLock.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/support/AbstractDistributedLock.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.lock.support;
+
+import org.springframework.cloud.cluster.lock.DistributedLock;
+
+/**
+ * Base implementation of {@link DistributedLock}.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public abstract class AbstractDistributedLock implements DistributedLock {
+
+	private final String lockKey;
+	
+	/**
+	 * Instantiates a new abstract distributed lock.
+	 *
+	 * @param lockKey the locking key
+	 */
+	public AbstractDistributedLock(String lockKey) {
+		this.lockKey = lockKey;
+	}
+
+	@Override
+	public String getLockKey() {
+		return lockKey;
+	}
+
+}

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/support/DefaultLockRegistry.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/support/DefaultLockRegistry.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.lock.support;
+
+import org.springframework.cloud.cluster.lock.DistributedLock;
+import org.springframework.cloud.cluster.lock.LockRegistry;
+import org.springframework.cloud.cluster.lock.LockService;
+import org.springframework.cloud.cluster.lock.LockServiceLocator;
+import org.springframework.cloud.cluster.lock.LockingException;
+import org.springframework.util.Assert;
+
+/**
+ * Default implementation of a {@link LockRegistry} delegating
+ * to a {@link LockServiceLocator}.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public class DefaultLockRegistry implements LockRegistry {
+
+	private final LockServiceLocator lockServiceLocator;
+
+	/**
+	 * Instantiates a new default lock registry.
+	 *
+	 * @param lockServiceLocator the lock service locator
+	 */
+	public DefaultLockRegistry(LockServiceLocator lockServiceLocator) {
+		Assert.notNull(lockServiceLocator, "Lock service locator must be set");
+		this.lockServiceLocator = lockServiceLocator;
+	}
+
+	@Override
+	public DistributedLock get(String lockKey) {
+		LockService service = lockServiceLocator.locate(lockKey);
+		if (service == null) {
+			throw new LockingException("Unable to find lockservice for key=["
+					+ lockKey + "]");
+		}
+		return service.obtain(lockKey);
+	}
+
+}

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/support/DefaultLockServiceLocator.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/support/DefaultLockServiceLocator.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.lock.support;
+
+import java.util.ArrayList;
+
+import org.springframework.cloud.cluster.lock.LockService;
+import org.springframework.cloud.cluster.lock.LockServiceLocator;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.Assert;
+import org.springframework.util.PathMatcher;
+
+/**
+ * Default implementation of a {@link LockServiceLocator} which
+ * uses a set of {@link LockService}s where matching happens using
+ * a simple {@link PathMatcher}.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public class DefaultLockServiceLocator implements LockServiceLocator {
+	
+	private final ArrayList<PathMapping> mappings = new ArrayList<PathMapping>();
+	
+	private final PathMatcher matcher = new AntPathMatcher();
+	
+	private final LockService fallback;
+	
+	/**
+	 * Instantiates a new default lock service locator.
+	 *
+	 * @param fallback the primary lock service
+	 */
+	public DefaultLockServiceLocator(LockService fallback) {
+		Assert.notNull(fallback, "Fallback lock service must be set");
+		this.fallback = fallback;
+	}
+
+	@Override
+	public LockService locate(String lockKey) {
+		LockService match = match(lockKey);
+		return match != null ? match : fallback;
+	}
+	
+	/**
+	 * Adds a mapping path for lock service.
+	 *
+	 * @param path the path
+	 * @param lockService the lock service
+	 */
+	public void addMapping(String path, LockService lockService) {
+		Assert.notNull(lockService, "Lock service must not be null");
+		mappings.add(new PathMapping(path, lockService));
+	}
+	
+	private LockService match(String path) {
+		for (PathMapping m : mappings) {
+			if (matcher.match(m.getPath(), path)) {
+				return m.getLockService();
+			}
+		}
+		return null;
+	}
+	
+	private static class PathMapping {
+		
+		private String path;
+		
+		private LockService lockService;
+		
+		public PathMapping(String path, LockService lockService) {
+			this.path = path;
+			this.lockService = lockService;
+		}
+		
+		public String getPath() {
+			return path;
+		}
+		
+		public LockService getLockService() {
+			return lockService;
+		}
+		
+	}
+
+}

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/support/DelegatingDistributedLock.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/support/DelegatingDistributedLock.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.lock.support;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+
+import org.springframework.cloud.cluster.lock.DistributedLock;
+import org.springframework.util.Assert;
+
+/**
+ * {@link DistributedLock} which simply delegates to a {@link Lock}.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public class DelegatingDistributedLock extends AbstractDistributedLock {
+	
+	private final Lock lock;
+	
+	/**
+	 * Instantiates a new delegating distributed lock.
+	 *
+	 * @param lockKey the locking key
+	 * @param lock the lock
+	 */
+	public DelegatingDistributedLock(String lockKey, Lock lock) {
+		super(lockKey);
+		Assert.notNull(lock, "Lock must be set");
+		this.lock = lock;
+	}
+
+	@Override
+	public void lock() {
+		lock.lock();
+	}
+
+	@Override
+	public void lockInterruptibly() throws InterruptedException {
+		lock.lockInterruptibly();
+	}
+
+	@Override
+	public boolean tryLock() {
+		return lock.tryLock();
+	}
+
+	@Override
+	public boolean tryLock(long time, TimeUnit unit)
+			throws InterruptedException {
+		return lock.tryLock(time, unit);
+	}
+
+	@Override
+	public void unlock() {
+		lock.unlock();
+	}
+
+	@Override
+	public Condition newCondition() {
+		return lock.newCondition();
+	}
+
+}

--- a/spring-cloud-cluster-core/src/test/java/org/springframework/cloud/cluster/TestUtils.java
+++ b/spring-cloud-cluster-core/src/test/java/org/springframework/cloud/cluster/TestUtils.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Utils for tests.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public class TestUtils {
+
+	@SuppressWarnings("unchecked")
+	public static <T> T readField(String name, Object target) throws Exception {
+		Field field = null;
+		Class<?> clazz = target.getClass();
+		do {
+			try {
+				field = clazz.getDeclaredField(name);
+			} catch (Exception ex) {
+			}
+
+			clazz = clazz.getSuperclass();
+		} while (field == null && !clazz.equals(Object.class));
+
+		if (field == null)
+			throw new IllegalArgumentException("Cannot find field '" + name + "' in the class hierarchy of "
+					+ target.getClass());
+		field.setAccessible(true);
+		return (T) field.get(target);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> T callMethod(String name, Object target) throws Exception {
+		Class<?> clazz = target.getClass();
+		Method method = ReflectionUtils.findMethod(clazz, name);
+
+		if (method == null)
+			throw new IllegalArgumentException("Cannot find method '" + method + "' in the class hierarchy of "
+					+ target.getClass());
+		method.setAccessible(true);
+		return (T) ReflectionUtils.invokeMethod(method, target);
+	}
+
+	public static void setField(String name, Object target, Object value) throws Exception {
+		Field field = null;
+		Class<?> clazz = target.getClass();
+		do {
+			try {
+				field = clazz.getDeclaredField(name);
+			} catch (Exception ex) {
+			}
+
+			clazz = clazz.getSuperclass();
+		} while (field == null && !clazz.equals(Object.class));
+
+		if (field == null)
+			throw new IllegalArgumentException("Cannot find field '" + name + "' in the class hierarchy of "
+					+ target.getClass());
+		field.setAccessible(true);
+		field.set(target, value);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> T callMethod(String name, Object target, Object[] args, Class<?>[] argsTypes) throws Exception {
+		Class<?> clazz = target.getClass();
+		Method method = ReflectionUtils.findMethod(clazz, name, argsTypes);
+
+		if (method == null)
+			throw new IllegalArgumentException("Cannot find method '" + method + "' in the class hierarchy of "
+					+ target.getClass());
+		method.setAccessible(true);
+		return (T) ReflectionUtils.invokeMethod(method, target, args);
+	}
+	
+}

--- a/spring-cloud-cluster-core/src/test/java/org/springframework/cloud/cluster/lock/AbstractLockingTests.java
+++ b/spring-cloud-cluster-core/src/test/java/org/springframework/cloud/cluster/lock/AbstractLockingTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.lock;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.springframework.cloud.cluster.lock.support.DelegatingDistributedLock;
+
+/**
+ * Base testing stuff for locking.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public abstract class AbstractLockingTests {
+
+	protected static class LockService1 extends BaseLockService {
+		public LockService1() {}
+	}
+
+	protected static class LockService2 extends BaseLockService {
+		public LockService2() {}
+	}
+
+	protected static class LockService3 extends BaseLockService {
+		public LockService3() {}
+	}
+	
+	protected abstract static class BaseLockService implements LockService {
+		
+		private Map<String, DistributedLock> locks = new HashMap<String, DistributedLock>();
+
+		@Override
+		public synchronized DistributedLock obtain(String lockKey) {
+			DistributedLock lock = locks.get(lockKey);
+			if (lock == null) {
+				ReentrantLock l = new ReentrantLock();
+				lock = new DelegatingDistributedLock(lockKey, l);
+				locks.put(lockKey, lock);
+			}
+			return lock;
+		}
+		
+	}
+	
+}

--- a/spring-cloud-cluster-core/src/test/java/org/springframework/cloud/cluster/lock/support/DefaultLockRegistryTests.java
+++ b/spring-cloud-cluster-core/src/test/java/org/springframework/cloud/cluster/lock/support/DefaultLockRegistryTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.lock.support;
+
+import org.junit.Test;
+import org.springframework.cloud.cluster.lock.LockService;
+import org.springframework.cloud.cluster.lock.LockServiceLocator;
+import org.springframework.cloud.cluster.lock.LockingException;
+
+/**
+ * Tests for {@link DefaultLockRegistry}.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public class DefaultLockRegistryTests {
+
+	@Test(expected = LockingException.class)
+	public void testFailureWithMissingLocate() {
+		DefaultLockRegistry registry = new DefaultLockRegistry(new AlwaysNullLockServiceLocator());
+		registry.get("cantfind");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testFailureWithNullLockService() {
+		new DefaultLockRegistry(null);
+	}	
+
+	private static class AlwaysNullLockServiceLocator implements LockServiceLocator {
+
+		@Override
+		public LockService locate(String lockKey) {
+			return null;
+		}
+		
+	}
+
+}

--- a/spring-cloud-cluster-core/src/test/java/org/springframework/cloud/cluster/lock/support/DefaultLockServiceLocatorTests.java
+++ b/spring-cloud-cluster-core/src/test/java/org/springframework/cloud/cluster/lock/support/DefaultLockServiceLocatorTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.lock.support;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.springframework.cloud.cluster.TestUtils;
+import org.springframework.cloud.cluster.lock.AbstractLockingTests;
+import org.springframework.cloud.cluster.lock.LockService;
+
+/**
+ * Tests for {@link DefaultLockServiceLocator}.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public class DefaultLockServiceLocatorTests extends AbstractLockingTests {
+
+	@Test
+	public void testPathMatching() throws Exception {
+		DefaultLockServiceLocator locator = new DefaultLockServiceLocator(
+				new LockService1());
+		locator.addMapping("/path2/**", new LockService2());
+		locator.addMapping("/path3/**", new LockService3());
+
+		LockService matched = match(locator, "/path2/dlock1");
+		assertThat(matched, instanceOf(LockService2.class));
+		
+		matched = match(locator, "/path3/dlock1");
+		assertThat(matched, instanceOf(LockService3.class));
+		
+		matched = match(locator, "/path1/dlock1");
+		assertThat(matched, nullValue());
+	}
+
+	@Test
+	public void testLockServiceLocate() throws Exception {
+		DefaultLockServiceLocator locator = new DefaultLockServiceLocator(
+				new LockService1());
+		locator.addMapping("/path2/**", new LockService2());
+		locator.addMapping("/path3/**", new LockService3());
+		
+		LockService service = locator.locate("/path1/dlock1");
+		assertThat(service, instanceOf(LockService1.class));
+
+		service = locator.locate("xxx");
+		assertThat(service, instanceOf(LockService1.class));
+		
+		service = locator.locate("/path2/dlock1");
+		assertThat(service, instanceOf(LockService2.class));
+		
+		service = locator.locate("/path3/dlock1");
+		assertThat(service, instanceOf(LockService3.class));
+	}
+	
+	private static LockService match(Object locator, String key)
+			throws Exception {
+		return TestUtils.callMethod("match", locator, new String[] { key },
+				new Class[] { String.class });
+	}
+	
+}

--- a/spring-cloud-cluster-redis/pom.xml
+++ b/spring-cloud-cluster-redis/pom.xml
@@ -4,11 +4,11 @@
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>spring-cloud-cluster-autoconfigure</artifactId>
+	<artifactId>spring-cloud-cluster-redis</artifactId>
 	<packaging>jar</packaging>
 
-	<name>spring-cloud-cluster-autoconfigure</name>
-	<description>Spring Cloud Cluster AutoConfigure</description>
+	<name>spring-cloud-cluster-redis</name>
+	<description>Spring Cloud Cluster Redis</description>
 
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
@@ -20,28 +20,15 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-cluster-zookeeper</artifactId>
-			<optional>true</optional>
+			<artifactId>spring-cloud-cluster-core</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-cluster-hazelcast</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-cluster-redis</artifactId>
-			<optional>true</optional>
+			<groupId>org.springframework.integration</groupId>
+			<artifactId>spring-integration-redis</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-configuration-processor</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.curator</groupId>
-			<artifactId>curator-test</artifactId>
-			<scope>test</scope>
+			<artifactId>spring-boot-starter-redis</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-cluster-redis/src/main/java/org/springframework/cloud/cluster/redis/RedisClusterProperties.java
+++ b/spring-cloud-cluster-redis/src/main/java/org/springframework/cloud/cluster/redis/RedisClusterProperties.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.redis;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Distributed locking properties for redis implementation.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+@ConfigurationProperties(value = "spring.cloud.cluster.redis")
+public class RedisClusterProperties {
+
+	private RedisDistributedLockProperties lock = new RedisDistributedLockProperties();
+	
+	public RedisDistributedLockProperties getLock() {
+		return lock;
+	}
+	
+	public void setLock(RedisDistributedLockProperties lock) {
+		this.lock = lock;
+	}
+	
+	public static class RedisDistributedLockProperties {
+
+		/** if redis distributed locking is enabled. */
+		private boolean enabled = true;
+		
+		/** key expire in milliseconds */
+		private Long expireAfter;
+	
+		public boolean isEnabled() {
+			return enabled;
+		}
+		
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+		
+		public Long getExpireAfter() {
+			return expireAfter;
+		}
+		
+		public void setExpireAfter(Long expireAfter) {
+			this.expireAfter = expireAfter;
+		}
+		
+	}
+	
+}

--- a/spring-cloud-cluster-redis/src/main/java/org/springframework/cloud/cluster/redis/lock/RedisLockService.java
+++ b/spring-cloud-cluster-redis/src/main/java/org/springframework/cloud/cluster/redis/lock/RedisLockService.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.redis.lock;
+
+import java.util.concurrent.locks.Lock;
+
+import org.springframework.cloud.cluster.lock.DistributedLock;
+import org.springframework.cloud.cluster.lock.LockService;
+import org.springframework.cloud.cluster.lock.support.DelegatingDistributedLock;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.integration.redis.util.RedisLockRegistry;
+
+/**
+ * {@link LockService} implementation based on Redis.
+ * 
+ * <p>This implementation delegates to {@link RedisLockRegistry} from Spring
+ * Integration.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public class RedisLockService implements LockService {
+	
+	public static final String DEFAULT_REGISTRY_KEY = "spring-cloud";
+	
+	private final RedisLockRegistry redisLockRegistry;
+
+	/**
+	 * Instantiates a new redis lock service.
+	 *
+	 * @param connectionFactory the redis connection factory
+	 */
+	public RedisLockService(RedisConnectionFactory connectionFactory) {
+		this(connectionFactory, DEFAULT_REGISTRY_KEY);
+	}
+
+	/**
+	 * Instantiates a new redis lock service.
+	 *
+	 * @param connectionFactory the redis connection factory
+	 * @param registryKey The key prefix for locks.
+	 */
+	public RedisLockService(RedisConnectionFactory connectionFactory, String registryKey) {
+		this.redisLockRegistry = new RedisLockRegistry(connectionFactory, registryKey);
+	}
+
+	/**
+	 * Instantiates a new redis lock service.
+	 *
+	 * @param connectionFactory the redis connection factory
+	 * @param expireAfter The expiration in milliseconds.
+	 */
+	public RedisLockService(RedisConnectionFactory connectionFactory, long expireAfter) {
+		this.redisLockRegistry = new RedisLockRegistry(connectionFactory, DEFAULT_REGISTRY_KEY, expireAfter);
+	}
+	
+	/**
+	 * Instantiates a new redis lock service.
+	 *
+	 * @param connectionFactory the redis connection factory
+	 * @param registryKey The key prefix for locks.
+	 * @param expireAfter The expiration in milliseconds.
+	 */
+	public RedisLockService(RedisConnectionFactory connectionFactory, String registryKey, long expireAfter) {
+		this.redisLockRegistry = new RedisLockRegistry(connectionFactory, registryKey, expireAfter);
+	}
+	
+	@Override
+	public DistributedLock obtain(String lockKey) {
+		Lock lock = redisLockRegistry.obtain(lockKey);
+		return new DelegatingDistributedLock(lockKey, lock);
+	}
+
+}

--- a/spring-cloud-cluster-redis/src/test/java/org/springframework/cloud/cluster/redis/lock/RedisIT.java
+++ b/spring-cloud-cluster-redis/src/test/java/org/springframework/cloud/cluster/redis/lock/RedisIT.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.cluster.redis.lock;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.redis.RedisAutoConfiguration;
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.cloud.cluster.lock.DistributedLock;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+/**
+ * Integration tests for redis locking using external redis server.
+ * 
+ * @author Janne Valkealahti
+ *
+ */
+public class RedisIT {
+
+	private AnnotationConfigApplicationContext context;
+	private RedisConnectionFactory connectionFactory;
+	private RedisTemplate<String, String> redisTemplate;
+
+	@Before
+	public void setup() {
+		context = new AnnotationConfigApplicationContext();
+		EnvironmentTestUtils.addEnvironment(context);
+		context.register(RedisAutoConfiguration.class);
+		context.refresh();
+		connectionFactory = context.getBean(RedisConnectionFactory.class);
+		redisTemplate = new RedisTemplate<String, String>();
+		redisTemplate.setConnectionFactory(connectionFactory);
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		redisTemplate.afterPropertiesSet();
+		cleanLocks();
+	}
+	
+	@After
+	public void close() {
+		cleanLocks();
+		context.close();
+	}
+	
+	private void cleanLocks() {
+		Set<String> keys = redisTemplate.keys(RedisLockService.DEFAULT_REGISTRY_KEY + ":*");
+		redisTemplate.delete(keys);
+	}
+	
+	@Test
+	public void testSimpleLock() {
+		RedisLockService lockService = new RedisLockService(connectionFactory);
+		DistributedLock lock = lockService.obtain("lock");
+		lock.lock();
+
+		Set<String> keys = redisTemplate.keys(RedisLockService.DEFAULT_REGISTRY_KEY + ":*");
+		assertThat(keys.size(), is(1));
+		assertThat(keys.iterator().next(), is(RedisLockService.DEFAULT_REGISTRY_KEY + ":lock"));
+		
+		lock.unlock();
+	}
+
+	@Test
+	public void testSecondLockSucceed() {
+		RedisLockService lockService = new RedisLockService(connectionFactory);
+		DistributedLock lock1 = lockService.obtain("lock");
+		DistributedLock lock2 = lockService.obtain("lock");
+		lock1.lock();
+		// same thread so try/lock doesn't fail
+		assertThat(lock2.tryLock(), is(true));
+		lock2.lock();
+
+		Set<String> keys = redisTemplate.keys(RedisLockService.DEFAULT_REGISTRY_KEY + ":*");
+		assertThat(keys.size(), is(1));
+		assertThat(keys.iterator().next(), is(RedisLockService.DEFAULT_REGISTRY_KEY + ":lock"));
+		
+		lock1.unlock();
+		lock2.unlock();
+	}
+	
+}


### PR DESCRIPTION
- This is a review PR for locking concepts.
- Changed a wrong auto-configure package name
- Base locking api's
  - I've tried to decouple user facing api(LockRegistry) from implementation
    api's(LockService).
  - Multiple locking services supported via (LockServiceLocator)
  - One concept around using multiple services is in DefaultLockServiceLocator
    which uses 'path' mappings to a locking services. This would then allow
    to use locking keys like '/zk/mykey' or '/redis/mykey'. Actual service would
    be registered to these paths using 'ant' style paths and keys would be resolved
    using AntPathMatcher.
- Redis locks based on SI's org.springframework.integration.redis.util.RedisLockRegistry