### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/cluster/autoconfigure/leader/EtcdLeaderAutoConfiguration.java
+++ b/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/cluster/autoconfigure/leader/EtcdLeaderAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/cluster/autoconfigure/leader/HazelcastLeaderAutoConfiguration.java
+++ b/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/cluster/autoconfigure/leader/HazelcastLeaderAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/cluster/autoconfigure/leader/LeaderAutoConfiguration.java
+++ b/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/cluster/autoconfigure/leader/LeaderAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/cluster/autoconfigure/leader/ZookeeperLeaderAutoConfiguration.java
+++ b/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/cluster/autoconfigure/leader/ZookeeperLeaderAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/cluster/autoconfigure/lock/RedisLockServiceAutoConfiguration.java
+++ b/spring-cloud-cluster-autoconfigure/src/main/java/org/springframework/cloud/cluster/autoconfigure/lock/RedisLockServiceAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/TestUtils.java
+++ b/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/TestUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/leader/AbstractLeaderAutoConfigurationTests.java
+++ b/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/leader/AbstractLeaderAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/leader/EtcdLeaderAutoConfigurationTests.java
+++ b/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/leader/EtcdLeaderAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/leader/HazelcastLeaderAutoConfigurationTests.java
+++ b/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/leader/HazelcastLeaderAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/leader/LeaderAutoConfigurationTests.java
+++ b/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/leader/LeaderAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/leader/ZookeeperLeaderAutoConfigurationTests.java
+++ b/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/leader/ZookeeperLeaderAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/lock/AbstractLockAutoConfigurationTests.java
+++ b/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/lock/AbstractLockAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/lock/RedisLockServiceAutoConfigurationTests.java
+++ b/spring-cloud-cluster-autoconfigure/src/test/java/org/springframework/cloud/cluster/autoconfigure/lock/RedisLockServiceAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/AbstractCandidate.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/AbstractCandidate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/Candidate.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/Candidate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/Context.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/Context.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/DefaultCandidate.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/DefaultCandidate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/LeaderElectionProperties.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/LeaderElectionProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/AbstractLeaderEvent.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/AbstractLeaderEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/DefaultLeaderEventPublisher.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/DefaultLeaderEventPublisher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/LeaderEventPublisher.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/LeaderEventPublisher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/LeaderEventPublisherConfiguration.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/LeaderEventPublisherConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/LoggingListener.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/LoggingListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/OnGrantedEvent.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/OnGrantedEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/OnRevokedEvent.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/leader/event/OnRevokedEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/DistributedLock.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/DistributedLock.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/DistributedLockProperties.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/DistributedLockProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/LockRegistry.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/LockRegistry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/LockService.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/LockService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/LockServiceLocator.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/LockServiceLocator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/LockingException.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/LockingException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/support/AbstractDistributedLock.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/support/AbstractDistributedLock.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/support/DefaultLockRegistry.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/support/DefaultLockRegistry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/support/DefaultLockServiceLocator.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/support/DefaultLockServiceLocator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/support/DelegatingDistributedLock.java
+++ b/spring-cloud-cluster-core/src/main/java/org/springframework/cloud/cluster/lock/support/DelegatingDistributedLock.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/test/java/org/springframework/cloud/cluster/TestUtils.java
+++ b/spring-cloud-cluster-core/src/test/java/org/springframework/cloud/cluster/TestUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/test/java/org/springframework/cloud/cluster/lock/AbstractLockingTests.java
+++ b/spring-cloud-cluster-core/src/test/java/org/springframework/cloud/cluster/lock/AbstractLockingTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/test/java/org/springframework/cloud/cluster/lock/support/DefaultLockRegistryTests.java
+++ b/spring-cloud-cluster-core/src/test/java/org/springframework/cloud/cluster/lock/support/DefaultLockRegistryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-core/src/test/java/org/springframework/cloud/cluster/lock/support/DefaultLockServiceLocatorTests.java
+++ b/spring-cloud-cluster-core/src/test/java/org/springframework/cloud/cluster/lock/support/DefaultLockServiceLocatorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-etcd/src/main/java/org/springframework/cloud/cluster/etcd/EtcdClusterProperties.java
+++ b/spring-cloud-cluster-etcd/src/main/java/org/springframework/cloud/cluster/etcd/EtcdClusterProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-etcd/src/main/java/org/springframework/cloud/cluster/etcd/leader/LeaderInitiator.java
+++ b/spring-cloud-cluster-etcd/src/main/java/org/springframework/cloud/cluster/etcd/leader/LeaderInitiator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-etcd/src/test/java/org/springframework/cloud/cluster/etcd/leader/EtcdTests.java
+++ b/spring-cloud-cluster-etcd/src/test/java/org/springframework/cloud/cluster/etcd/leader/EtcdTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-hazelcast/src/main/java/org/springframework/cloud/cluster/hazelcast/HazelcastClusterProperties.java
+++ b/spring-cloud-cluster-hazelcast/src/main/java/org/springframework/cloud/cluster/hazelcast/HazelcastClusterProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-hazelcast/src/main/java/org/springframework/cloud/cluster/hazelcast/leader/LeaderInitiator.java
+++ b/spring-cloud-cluster-hazelcast/src/main/java/org/springframework/cloud/cluster/hazelcast/leader/LeaderInitiator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-hazelcast/src/test/java/org/springframework/cloud/cluster/hazelcast/leader/HazelcastTests.java
+++ b/spring-cloud-cluster-hazelcast/src/test/java/org/springframework/cloud/cluster/hazelcast/leader/HazelcastTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-redis/src/main/java/org/springframework/cloud/cluster/redis/RedisClusterProperties.java
+++ b/spring-cloud-cluster-redis/src/main/java/org/springframework/cloud/cluster/redis/RedisClusterProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-redis/src/main/java/org/springframework/cloud/cluster/redis/lock/RedisLockService.java
+++ b/spring-cloud-cluster-redis/src/main/java/org/springframework/cloud/cluster/redis/lock/RedisLockService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-redis/src/test/java/org/springframework/cloud/cluster/redis/lock/RedisIT.java
+++ b/spring-cloud-cluster-redis/src/test/java/org/springframework/cloud/cluster/redis/lock/RedisIT.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-zookeeper/src/main/java/org/springframework/cloud/cluster/zk/ZookeeperClusterProperties.java
+++ b/spring-cloud-cluster-zookeeper/src/main/java/org/springframework/cloud/cluster/zk/ZookeeperClusterProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-zookeeper/src/main/java/org/springframework/cloud/cluster/zk/curator/CuratorFrameworkFactoryBean.java
+++ b/spring-cloud-cluster-zookeeper/src/main/java/org/springframework/cloud/cluster/zk/curator/CuratorFrameworkFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-zookeeper/src/main/java/org/springframework/cloud/cluster/zk/leader/LeaderInitiator.java
+++ b/spring-cloud-cluster-zookeeper/src/main/java/org/springframework/cloud/cluster/zk/leader/LeaderInitiator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-zookeeper/src/test/java/org/springframework/cloud/cluster/zk/curator/CuratorFrameworkFactoryBeanTests.java
+++ b/spring-cloud-cluster-zookeeper/src/test/java/org/springframework/cloud/cluster/zk/curator/CuratorFrameworkFactoryBeanTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-cluster-zookeeper/src/test/java/org/springframework/cloud/cluster/zk/leader/ZookeeperTests.java
+++ b/spring-cloud-cluster-zookeeper/src/test/java/org/springframework/cloud/cluster/zk/leader/ZookeeperTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 54 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).